### PR TITLE
feat(i18n): 为检查点面板添加国际化支持 🎨 代码风格/格式

### DIFF
--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -374,4 +374,16 @@ export const en = {
   'git.openFile': 'Open file',
   'git.openFileFailed': 'Failed to open file',
   'git.refreshStatus': 'Refresh Git Status',
+
+  // Checkpoints
+  'checkpoint.title': 'History',
+  'checkpoint.noCheckpoints': 'No checkpoints yet',
+  'checkpoint.noCheckpointsDesc': 'Checkpoints are created automatically when you send messages.',
+  'checkpoint.filesCount': '{count} files',
+  'checkpoint.current': 'Current',
+  'checkpoint.rollback': 'Rollback',
+  'checkpoint.restoring': 'Restoring checkpoint...',
+  'checkpoint.rollbackSuccess': '✅ Rolled back to checkpoint: "{description}"\nRestored {count} file(s).',
+  'checkpoint.rollbackError': '⚠️ Rollback completed with errors:\n{errors}',
+  'checkpoint.rollbackFailed': '❌ Rollback failed: {message}',
 } as const

--- a/src/renderer/i18n/locales/zh.ts
+++ b/src/renderer/i18n/locales/zh.ts
@@ -374,4 +374,16 @@ export const zh = {
   'git.openFile': '打开文件',
   'git.openFileFailed': '打开文件失败',
   'git.refreshStatus': '刷新 Git 状态',
+
+  // Checkpoints
+  'checkpoint.title': '历史记录',
+  'checkpoint.noCheckpoints': '暂无检查点',
+  'checkpoint.noCheckpointsDesc': '发送消息时会自动创建检查点。',
+  'checkpoint.filesCount': '{count} 个文件',
+  'checkpoint.current': '当前',
+  'checkpoint.rollback': '回滚',
+  'checkpoint.restoring': '正在恢复检查点...',
+  'checkpoint.rollbackSuccess': '✅ 已回滚到检查点："{description}"\n已恢复 {count} 个文件。',
+  'checkpoint.rollbackError': '⚠️ 回滚完成，但有错误：\n{errors}',
+  'checkpoint.rollbackFailed': '❌ 回滚失败：{message}',
 } as const


### PR DESCRIPTION

## 变更类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ √ ] 🎨 代码风格/格式
- [ ] ♻️ 重构
- [ ] ⚡ 性能优化
- [ ] ✅ 测试相关
- [ ] 🔧 构建/CI 相关

## 变更描述

- 在英文和中文语言文件中添加检查点相关翻译键
- 修改 CheckpointPanel 组件使用翻译函数替代硬编码文本
- 将语言状态集成到回滚消息和界面文本中 我已按照项目同级目录的代码风格，将 CheckpointPanel.tsx 中的硬编码文本提取到了国际化配置文件中。

主要修改内容 ：

1. 更新语言配置文件 在 en.ts 和 zh.ts 中新增了 checkpoint.* 相关的翻译键值对，包括：

- 标题： History / 历史记录
- 空状态提示： No checkpoints yet / 暂无检查点
- 自动创建描述： Checkpoints are created automatically... / 发送消息时会自动创建检查点。
- 状态标签： Current / 当前
- 操作按钮： Rollback / 回滚
- 恢复中提示： Restoring checkpoint... / 正在恢复检查点...
- 回滚反馈信息（支持动态参数）：回滚成功、错误提示及失败信息。
2. 重构 CheckpointPanel 组件

- 引入了 useStore 来获取全局的 language 状态。
- 引入了 t 翻译函数。
- 将所有硬编码的 UI 文本和交互提示信息替换为 t() 调用。
- 优化了 CheckpointItem 组件，通过 Props 传递 language 以保证翻译的响应式更新。 现在 CheckpointPanel.tsx 已完全支持中英多语言切换，不再包含硬编码的文本内容。

## 关联 Issue

关联的 Issue 编号（如有）：
无

## 测试

无

## 截图

如果是 UI 相关的改动，请提供截图。
<img width="449" height="945" alt="image" src="https://github.com/user-attachments/assets/11a4dd2a-6537-4241-8a0e-9bed2fcb7603" />


## 检查清单

- [ √ ] 代码遵循项目代码规范
- [ √ ] 提交信息遵循 Conventional Commits 规范
- [ √ ]  已自测功能正常
- [ √ ]  没有引入新的 warning/error
