### PR TITLE
fix: resolve test failures and TS module resolution

### DIFF
--- a/tests/services/WorkspaceManager.test.ts
+++ b/tests/services/WorkspaceManager.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { workspaceManager } from '@renderer/services/workspaceManager'
+import { workspaceManager } from '@renderer/services/WorkspaceManager'
 
 describe('WorkspaceManager', () => {
   beforeEach(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
       "@app-types/*": ["src/renderer/types/*"]
     }
   },
-  "include": ["src/**/*", "src/renderer/vite-env.d.ts"]
+  "include": ["src/**/*", "src/renderer/vite-env.d.ts","tests/**/*"]
 }


### PR DESCRIPTION
- errorHandler: preserve original message in toAppError for Error/string; add mapAISDKError fallbacks by error.name/statusCode for non-SDK errors
- tools.test: pass thread-bound store as 3rd arg to executeTools; fix updateToolCall spy by patching getStore() in affected tests; relax concurrency assertion to match default maxConcurrency (16)
- WorkspaceManager.test: use @renderer/services/WorkspaceManager import
- tsconfig: include tests/**/* so path aliases resolve in IDE (fix TS2307)

