### PR TITLE
fix: 修复 macOS 上所有快捷键无法使用 Command(⌘) 键的问题

### DIFF
--- a/src/renderer/components/dialogs/CommandPalette.tsx
+++ b/src/renderer/components/dialogs/CommandPalette.tsx
@@ -15,7 +15,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useAgentStore } from '@/renderer/agent'
 import { useAgent } from '@/renderer/hooks/useAgent'
 import { t } from '@/renderer/i18n'
-import { keybindingService } from '@/renderer/services/keybindingService'
+import { keybindingService, formatShortcut, isMac } from '@/renderer/services/keybindingService'
 import { adnifyDir } from '@/renderer/services/adnifyDirService'
 import { toast } from '@/renderer/components/common/ToastProvider'
 
@@ -189,7 +189,7 @@ export default function CommandPalette({ onClose, onShowKeyboardShortcuts }: Com
       icon: FolderOpen,
       category: 'File',
       action: () => api.file.openFolder(),
-      shortcut: 'Ctrl+O',
+      shortcut: formatShortcut('Ctrl+O'),
     },
     {
       id: 'new-window',
@@ -198,7 +198,7 @@ export default function CommandPalette({ onClose, onShowKeyboardShortcuts }: Com
       icon: Plus,
       category: 'Window',
       action: () => api.window.new(),
-      shortcut: 'Ctrl+Shift+N',
+      shortcut: formatShortcut('Ctrl+Shift+N'),
     },
     {
       id: 'add-folder',
@@ -238,9 +238,13 @@ export default function CommandPalette({ onClose, onShowKeyboardShortcuts }: Com
       icon: Save,
       category: 'File',
       action: () => {
-        document.dispatchEvent(new KeyboardEvent('keydown', { key: 's', ctrlKey: true }))
+        document.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 's',
+          ctrlKey: !isMac,
+          metaKey: isMac,
+        }))
       },
-      shortcut: 'Ctrl+S',
+      shortcut: formatShortcut('Ctrl+S'),
     },
     {
       id: 'refresh-files',
@@ -266,7 +270,7 @@ export default function CommandPalette({ onClose, onShowKeyboardShortcuts }: Com
       icon: Search,
       category: 'File',
       action: () => setShowQuickOpen(true),
-      shortcut: 'Ctrl+P',
+      shortcut: formatShortcut('Ctrl+P'),
     },
     {
       id: 'toggle-terminal',
@@ -275,7 +279,7 @@ export default function CommandPalette({ onClose, onShowKeyboardShortcuts }: Com
       icon: Terminal,
       category: 'View',
       action: () => setTerminalVisible(!terminalVisible),
-      shortcut: 'Ctrl+`',
+      shortcut: formatShortcut('Ctrl+`'),
     },
     {
       id: 'open-composer',
@@ -284,7 +288,7 @@ export default function CommandPalette({ onClose, onShowKeyboardShortcuts }: Com
       icon: Sparkles,
       category: 'AI Tools',
       action: () => setShowComposer(true),
-      shortcut: 'Ctrl+Shift+I',
+      shortcut: formatShortcut('Ctrl+Shift+I'),
     },
     {
       id: 'settings',
@@ -293,7 +297,7 @@ export default function CommandPalette({ onClose, onShowKeyboardShortcuts }: Com
       icon: Settings,
       category: 'Preferences',
       action: () => setShowSettings(true),
-      shortcut: 'Ctrl+,',
+      shortcut: formatShortcut('Ctrl+,'),
     },
     {
       id: 'keyboard-shortcuts',

--- a/src/renderer/components/dialogs/KeyboardShortcuts.tsx
+++ b/src/renderer/components/dialogs/KeyboardShortcuts.tsx
@@ -4,6 +4,7 @@
 
 import { memo } from 'react'
 import { Keyboard, X } from 'lucide-react'
+import { formatShortcutKeys } from '@services/keybindingService'
 
 interface ShortcutItem {
   keys: string[]
@@ -100,7 +101,7 @@ export default function KeyboardShortcuts({ onClose }: KeyboardShortcutsProps) {
                         {shortcut.description}
                       </span>
                       <div className="flex items-center gap-1">
-                        {shortcut.keys.map((key, keyIdx) => (
+                        {formatShortcutKeys(shortcut.keys).map((key, keyIdx) => (
                           <span key={keyIdx} className="flex items-center">
                             <ShortcutKey keyName={key} />
                             {keyIdx < shortcut.keys.length - 1 && (

--- a/src/renderer/components/editor/EditorContextMenu.tsx
+++ b/src/renderer/components/editor/EditorContextMenu.tsx
@@ -9,6 +9,7 @@ import { api } from '@/renderer/services/electronAPI'
 import { t, TranslationKey } from '@renderer/i18n'
 import { getIncomingCalls, getOutgoingCalls, lspUriToPath } from '@renderer/services/lspService'
 import { getFileName } from '@shared/utils/pathUtils'
+import { formatShortcut } from '@services/keybindingService'
 import type { editor } from 'monaco-editor'
 import { logger } from '@shared/utils/Logger'
 
@@ -285,24 +286,24 @@ export default function EditorContextMenu({ x, y, editor, onClose }: EditorConte
     // 导航
     { id: 'goto-def', labelKey: 'ctxGotoDefinition', shortcut: 'F12', action: () => runAction('editor.action.revealDefinition') },
     { id: 'find-refs', labelKey: 'ctxFindReferences', shortcut: 'Shift+F12', action: () => runAction('editor.action.goToReferences') },
-    { id: 'goto-symbol', labelKey: 'ctxGotoSymbol', shortcut: 'Ctrl+Shift+O', action: () => runAction('editor.action.quickOutline') },
+    { id: 'goto-symbol', labelKey: 'ctxGotoSymbol', shortcut: formatShortcut('Ctrl+Shift+O'), action: () => runAction('editor.action.quickOutline') },
     { id: 'find-callers', labelKey: 'ctxFindCallers', action: handleFindCallers, disabled: !supportsCallHierarchy },
     { id: 'find-callees', labelKey: 'ctxFindCallees', action: handleFindCallees, divider: true, disabled: !supportsCallHierarchy },
     // 编辑
     { id: 'rename', labelKey: 'ctxRename', shortcut: 'F2', action: () => runAction('editor.action.rename') },
-    { id: 'change-all', labelKey: 'ctxChangeAll', shortcut: 'Ctrl+F2', action: () => runAction('editor.action.changeAll') },
-    { id: 'format', labelKey: 'ctxFormat', shortcut: 'Shift+Alt+F', action: () => runAction('editor.action.formatDocument'), divider: true },
+    { id: 'change-all', labelKey: 'ctxChangeAll', shortcut: formatShortcut('Ctrl+F2'), action: () => runAction('editor.action.changeAll') },
+    { id: 'format', labelKey: 'ctxFormat', shortcut: formatShortcut('Shift+Alt+F'), action: () => runAction('editor.action.formatDocument'), divider: true },
     // 剪贴板
-    { id: 'cut', labelKey: 'ctxCut', shortcut: 'Ctrl+X', action: handleCut },
-    { id: 'copy', labelKey: 'ctxCopy', shortcut: 'Ctrl+C', action: handleCopy },
-    { id: 'paste', labelKey: 'ctxPaste', shortcut: 'Ctrl+V', action: handlePaste, divider: true },
+    { id: 'cut', labelKey: 'ctxCut', shortcut: formatShortcut('Ctrl+X'), action: handleCut },
+    { id: 'copy', labelKey: 'ctxCopy', shortcut: formatShortcut('Ctrl+C'), action: handleCopy },
+    { id: 'paste', labelKey: 'ctxPaste', shortcut: formatShortcut('Ctrl+V'), action: handlePaste, divider: true },
     // 查找
-    { id: 'find', labelKey: 'ctxFind', shortcut: 'Ctrl+F', action: () => runAction('actions.find') },
-    { id: 'replace', labelKey: 'ctxReplace', shortcut: 'Ctrl+H', action: () => runAction('editor.action.startFindReplaceAction'), divider: true },
+    { id: 'find', labelKey: 'ctxFind', shortcut: formatShortcut('Ctrl+F'), action: () => runAction('actions.find') },
+    { id: 'replace', labelKey: 'ctxReplace', shortcut: formatShortcut('Ctrl+H'), action: () => runAction('editor.action.startFindReplaceAction'), divider: true },
     // 其他
-    { id: 'comment', labelKey: 'ctxToggleComment', shortcut: 'Ctrl+/', action: () => runAction('editor.action.commentLine') },
-    { id: 'delete-line', labelKey: 'ctxDeleteLine', shortcut: 'Ctrl+Shift+K', action: () => runAction('editor.action.deleteLines') },
-    { id: 'select-next', labelKey: 'ctxSelectNext', shortcut: 'Ctrl+D', action: () => runAction('editor.action.addSelectionToNextFindMatch'), divider: true },
+    { id: 'comment', labelKey: 'ctxToggleComment', shortcut: formatShortcut('Ctrl+/'), action: () => runAction('editor.action.commentLine') },
+    { id: 'delete-line', labelKey: 'ctxDeleteLine', shortcut: formatShortcut('Ctrl+Shift+K'), action: () => runAction('editor.action.deleteLines') },
+    { id: 'select-next', labelKey: 'ctxSelectNext', shortcut: formatShortcut('Ctrl+D'), action: () => runAction('editor.action.addSelectionToNextFindMatch'), divider: true },
     // 文件操作
     { 
       id: 'open-in-browser', 

--- a/src/renderer/components/editor/TabContextMenu.tsx
+++ b/src/renderer/components/editor/TabContextMenu.tsx
@@ -5,7 +5,7 @@
 import { api } from '@/renderer/services/electronAPI'
 import { useRef, useEffect } from 'react'
 import { toast } from '../common/ToastProvider'
-import { keybindingService } from '@services/keybindingService'
+import { keybindingService, formatShortcut } from '@services/keybindingService'
 
 interface TabContextMenuProps {
   x: number
@@ -45,12 +45,12 @@ export function TabContextMenu({
   }, [onClose])
 
   const menuItems = [
-    { label: isZh ? '关闭' : 'Close', action: () => onCloseFile(filePath), shortcut: 'Ctrl+W' },
+    { label: isZh ? '关闭' : 'Close', action: () => onCloseFile(filePath), shortcut: formatShortcut('Ctrl+W') },
     { label: isZh ? '关闭其他' : 'Close Others', action: () => onCloseOthers(filePath) },
     { label: isZh ? '关闭右侧' : 'Close to the Right', action: () => onCloseToRight(filePath) },
     { label: isZh ? '关闭全部' : 'Close All', action: () => onCloseAll() },
     { type: 'separator' as const },
-    { label: isZh ? '保存' : 'Save', action: () => onSave(filePath), shortcut: 'Ctrl+S', disabled: !isDirty },
+    { label: isZh ? '保存' : 'Save', action: () => onSave(filePath), shortcut: formatShortcut('Ctrl+S'), disabled: !isDirty },
     { type: 'separator' as const },
     {
       label: isZh ? '复制路径' : 'Copy Path',

--- a/src/renderer/components/layout/ActivityBar.tsx
+++ b/src/renderer/components/layout/ActivityBar.tsx
@@ -3,6 +3,7 @@ import { Tooltip } from '../ui/Tooltip'
 import { useStore } from '@store'
 import { useShallow } from 'zustand/react/shallow'
 import { t } from '@renderer/i18n'
+import { formatShortcut } from '@services/keybindingService'
 
 export default function ActivityBar() {
   const { activeSidePanel, setActiveSidePanel, language, setShowSettings, setShowComposer } = useStore(useShallow(s => ({ activeSidePanel: s.activeSidePanel, setActiveSidePanel: s.setActiveSidePanel, language: s.language, setShowSettings: s.setShowSettings, setShowComposer: s.setShowComposer })))
@@ -49,7 +50,7 @@ export default function ActivityBar() {
 
       {/* Bottom Actions */}
       <div className="flex flex-col w-full items-center gap-3 pb-2">
-        <Tooltip content={`${t('composer', language)} (Ctrl+Shift+I)`} side="right">
+        <Tooltip content={`${t('composer', language)} (${formatShortcut('Ctrl+Shift+I')})`} side="right">
           <button
             onClick={() => setShowComposer(true)}
             className="w-10 h-10 rounded-xl flex items-center justify-center text-text-muted hover:text-text-primary hover:bg-surface-hover active:scale-95 transition-all duration-300 group"

--- a/src/renderer/components/panels/KeybindingPanel.tsx
+++ b/src/renderer/components/panels/KeybindingPanel.tsx
@@ -1,7 +1,7 @@
 
 import { useEffect, useState } from 'react'
 import { Search, RotateCcw } from 'lucide-react'
-import { keybindingService, Command } from '@services/keybindingService'
+import { keybindingService, Command, formatShortcut, isMac } from '@services/keybindingService'
 import { registerCoreCommands } from '@renderer/config/commands'
 import { useStore } from '@store'
 import { t, type TranslationKey } from '@renderer/i18n'
@@ -37,10 +37,15 @@ export default function KeybindingPanel() {
         e.stopPropagation()
 
         const modifiers = []
-        if (e.ctrlKey) modifiers.push('Ctrl')
+        if (isMac) {
+            if (e.metaKey) modifiers.push('Ctrl')
+            if (e.ctrlKey) modifiers.push('Control')
+        } else {
+            if (e.ctrlKey) modifiers.push('Ctrl')
+            if (e.metaKey) modifiers.push('Meta')
+        }
         if (e.shiftKey) modifiers.push('Shift')
         if (e.altKey) modifiers.push('Alt')
-        if (e.metaKey) modifiers.push('Meta')
 
         let key = e.key
         if (key === 'Control' || key === 'Shift' || key === 'Alt' || key === 'Meta') return
@@ -97,7 +102,7 @@ export default function KeybindingPanel() {
                                     onClick={() => setRecordingId(cmd.id)}
                                     className="font-mono min-w-[80px]"
                                 >
-                                    {bindings[cmd.id] || '-'}
+                                    {bindings[cmd.id] ? formatShortcut(bindings[cmd.id]) : '-'}
                                 </Button>
 
                                 {keybindingService.isOverridden(cmd.id) && (

--- a/src/renderer/components/panels/TerminalPanel.tsx
+++ b/src/renderer/components/panels/TerminalPanel.tsx
@@ -18,6 +18,7 @@ import { terminalManager, TerminalManagerState } from '@/renderer/services/Termi
 import { XTERM_STYLE, getTerminalTheme } from '@/renderer/services/xtermTheme'
 import { useClickOutside } from '@renderer/hooks/usePerformance'
 import { t } from '@renderer/i18n'
+import { formatShortcut } from '@services/keybindingService'
 
 const TerminalPanel = memo(function TerminalPanel() {
     const { terminalVisible, setTerminalVisible, workspace, currentTheme, terminalLayout, setTerminalLayout, language } = useStore(useShallow(s => ({ terminalVisible: s.terminalVisible, setTerminalVisible: s.setTerminalVisible, workspace: s.workspace, currentTheme: s.currentTheme, terminalLayout: s.terminalLayout, setTerminalLayout: s.setTerminalLayout, language: s.language })))
@@ -460,7 +461,7 @@ const TerminalPanel = memo(function TerminalPanel() {
                             }}
                         >
                             <span>{t('newTerminal', language)}</span>
-                            <span className="text-[10px] text-text-muted">Ctrl+Shift+`</span>
+                            <span className="text-[10px] text-text-muted">{formatShortcut('Ctrl+Shift+`')}</span>
                         </button>
                         <button
                             className="flex items-center justify-between w-full px-3 py-1.5 hover:bg-surface-hover"
@@ -471,7 +472,7 @@ const TerminalPanel = memo(function TerminalPanel() {
                             }}
                         >
                             <span>{t('splitTerminal', language)}</span>
-                            <span className="text-[10px] text-text-muted">Ctrl+Shift+5</span>
+                            <span className="text-[10px] text-text-muted">{formatShortcut('Ctrl+Shift+5')}</span>
                         </button>
 
                         <div className="my-1 h-px bg-border/60" />
@@ -492,7 +493,7 @@ const TerminalPanel = memo(function TerminalPanel() {
                             }}
                         >
                             <span>{t('ctxCopy', language)}</span>
-                            <span className="text-[10px] text-text-muted">Ctrl+Shift+C</span>
+                            <span className="text-[10px] text-text-muted">{formatShortcut('Ctrl+Shift+C')}</span>
                         </button>
                         <button
                             className="flex items-center justify-between w-full px-3 py-1.5 hover:bg-surface-hover"
@@ -509,7 +510,7 @@ const TerminalPanel = memo(function TerminalPanel() {
                             }}
                         >
                             <span>{t('ctxPaste', language)}</span>
-                            <span className="text-[10px] text-text-muted">Ctrl+Shift+V</span>
+                            <span className="text-[10px] text-text-muted">{formatShortcut('Ctrl+Shift+V')}</span>
                         </button>
                         <button
                             className="flex items-center justify-between w-full px-3 py-1.5 hover:bg-surface-hover"

--- a/src/renderer/components/welcome/WelcomePage.tsx
+++ b/src/renderer/components/welcome/WelcomePage.tsx
@@ -8,6 +8,7 @@ import { FolderOpen, History, Folder, Plus, Settings } from 'lucide-react'
 import { api } from '@/renderer/services/electronAPI'
 import { workspaceManager } from '@/renderer/services/WorkspaceManager'
 import { useStore } from '@/renderer/store'
+import { formatShortcut } from '@services/keybindingService'
 import { logger } from '@utils/Logger'
 import { toast } from '@components/common/ToastProvider'
 import { Logo } from '../common/Logo'
@@ -164,7 +165,7 @@ export default function WelcomePage() {
         {/* Footer Hint */}
         <div className="mt-16 text-center flex-shrink-0">
           <p className="text-[11px] text-text-muted font-bold uppercase tracking-widest opacity-40">
-            {language === 'zh' ? '按' : 'Press'} <kbd className="mx-1.5 px-2 py-1 bg-surface-muted border border-border-subtle rounded-md text-text-primary font-mono text-[10px] shadow-sm">Ctrl+Shift+O</kbd> {language === 'zh' ? '打开命令面板' : 'for commands'}
+            {language === 'zh' ? '按' : 'Press'} <kbd className="mx-1.5 px-2 py-1 bg-surface-muted border border-border-subtle rounded-md text-text-primary font-mono text-[10px] shadow-sm">{formatShortcut('Ctrl+Shift+O')}</kbd> {language === 'zh' ? '打开命令面板' : 'for commands'}
           </p>
         </div>
       </div>

--- a/src/renderer/hooks/useGlobalShortcuts.ts
+++ b/src/renderer/hooks/useGlobalShortcuts.ts
@@ -7,6 +7,9 @@
 import { useEffect, useCallback, useRef } from 'react'
 import { useStore } from '@store'
 import { api } from '@renderer/services/electronAPI'
+import { isMac } from '@services/keybindingService'
+
+const primaryMod = (e: KeyboardEvent) => isMac ? e.metaKey : e.ctrlKey
 
 export function useGlobalShortcuts() {
   // setter 函数引用稳定，直接从 store 获取
@@ -44,15 +47,17 @@ export function useGlobalShortcuts() {
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     const s = stateRef.current
 
-    // Command Palette: Ctrl+Shift+O or F1
-    if (e.key === 'F1' || (e.ctrlKey && e.shiftKey && e.key === 'O')) {
+    const mod = primaryMod(e)
+
+    // Command Palette: Ctrl/Cmd+Shift+O or F1
+    if (e.key === 'F1' || (mod && e.shiftKey && e.key === 'O')) {
       e.preventDefault()
       setShowCommandPalette(true)
       return
     }
 
-    // Quick Open: Ctrl+P
-    if (e.ctrlKey && e.key.toLowerCase() === 'p' && !e.altKey) {
+    // Quick Open: Ctrl/Cmd+P
+    if (mod && e.key.toLowerCase() === 'p' && !e.altKey) {
       e.preventDefault()
       setShowQuickOpen(true)
       return
@@ -64,22 +69,22 @@ export function useGlobalShortcuts() {
       return
     }
 
-    // Settings: Ctrl+,
-    if (e.ctrlKey && e.key === ',') {
+    // Settings: Ctrl/Cmd+,
+    if (mod && e.key === ',') {
       e.preventDefault()
       setShowSettings(true)
       return
     }
 
-    // Terminal: Ctrl+`
-    if (e.ctrlKey && (e.key === '`' || e.code === 'Backquote')) {
+    // Terminal: Ctrl/Cmd+`
+    if (mod && (e.key === '`' || e.code === 'Backquote')) {
       e.preventDefault()
       setTerminalVisible(!s.terminalVisible)
       return
     }
 
-    // Debug: Ctrl+Shift+D
-    if (e.ctrlKey && (e.key === 'D' || (e.shiftKey && e.key.toLowerCase() === 'd'))) {
+    // Debug: Ctrl/Cmd+Shift+D
+    if (mod && (e.key === 'D' || (e.shiftKey && e.key.toLowerCase() === 'd'))) {
       e.preventDefault()
       setDebugVisible(!s.debugVisible)
       return
@@ -99,8 +104,8 @@ export function useGlobalShortcuts() {
       return
     }
 
-    // Composer: Ctrl+Shift+I
-    if (e.ctrlKey && (e.key === 'I' || (e.shiftKey && e.key.toLowerCase() === 'i'))) {
+    // Composer: Ctrl/Cmd+Shift+I
+    if (mod && (e.key === 'I' || (e.shiftKey && e.key.toLowerCase() === 'i'))) {
       e.preventDefault()
       setShowComposer(true)
       return
@@ -115,8 +120,8 @@ export function useGlobalShortcuts() {
       return
     }
 
-    // Reveal active file in explorer: Ctrl+Shift+E
-    if (e.ctrlKey && (e.key === 'E' || (e.shiftKey && e.key.toLowerCase() === 'e'))) {
+    // Reveal active file in explorer: Ctrl/Cmd+Shift+E
+    if (mod && (e.key === 'E' || (e.shiftKey && e.key.toLowerCase() === 'e'))) {
       e.preventDefault()
       window.dispatchEvent(new CustomEvent('explorer:reveal-active-file'))
       return
@@ -129,8 +134,8 @@ export function useGlobalShortcuts() {
       return
     }
 
-    // Close active file: Ctrl+W
-    if (e.ctrlKey && e.key.toLowerCase() === 'w') {
+    // Close active file: Ctrl/Cmd+W
+    if (mod && e.key.toLowerCase() === 'w') {
       e.preventDefault()
       if (s.activeFilePath) {
         closeFile(s.activeFilePath)

--- a/src/renderer/services/TerminalManager.ts
+++ b/src/renderer/services/TerminalManager.ts
@@ -17,6 +17,7 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { getEditorConfig } from "@renderer/settings";
 import { logger } from "@utils/Logger";
 import { toAppError } from "@shared/utils/errorHandler";
+import { isMac } from "@services/keybindingService";
 
 // ===== 类型定义 =====
 
@@ -441,24 +442,25 @@ class TerminalManagerClass {
       api.terminal.write(id, text);
     };
 
-    // 处理复制粘贴快捷键
+    const mod = (e: KeyboardEvent) => isMac ? e.metaKey : e.ctrlKey;
+
     terminal.attachCustomKeyEventHandler((event) => {
-      // Ctrl+C 复制（有选中内容时）
-      if (event.ctrlKey && event.key === "c" && event.type === "keydown") {
+      // Cmd/Ctrl+C 复制（有选中内容时）
+      if (mod(event) && event.key === "c" && event.type === "keydown") {
         const selection = terminal.getSelection();
         if (selection) {
           navigator.clipboard.writeText(selection);
-          return false; // 阻止默认行为
+          return false;
         }
-        // 没有选中内容时，让 Ctrl+C 发送到终端（中断信号）
+        // macOS 上 Cmd+C 没有选中内容时不发送中断信号；Ctrl+C 在 macOS 仍发中断
+        if (isMac) return false;
         return true;
       }
 
-      // Only handle keydown events to prevent duplicate execution
       if (event.type !== "keydown") return true;
 
-      // Ctrl+V for paste
-      if (event.ctrlKey && !event.shiftKey && event.key === "v") {
+      // Cmd/Ctrl+V for paste
+      if (mod(event) && !event.shiftKey && event.key === "v") {
         event.preventDefault();
         navigator.clipboard.readText().then((text) => {
           handlePasteText(text);
@@ -466,7 +468,7 @@ class TerminalManagerClass {
         return false;
       }
 
-      // Ctrl+Shift+C 复制（备用）
+      // Ctrl+Shift+C 复制（备用，非 macOS）
       if (
         event.ctrlKey &&
         event.shiftKey &&
@@ -480,7 +482,7 @@ class TerminalManagerClass {
         return false;
       }
 
-      // Ctrl+Shift+V 粘贴（备用）
+      // Ctrl+Shift+V 粘贴（备用，非 macOS）
       if (
         event.ctrlKey &&
         event.shiftKey &&

--- a/src/renderer/services/keybindingService.ts
+++ b/src/renderer/services/keybindingService.ts
@@ -1,7 +1,9 @@
 import { api } from '@/renderer/services/electronAPI'
 import { logger } from '@utils/Logger'
+import { platform } from '@shared/utils/pathUtils'
 
 const LOCAL_STORAGE_KEY = 'adnify-keybindings'
+const isMac = platform.isMac
 
 export interface Command {
     id: string
@@ -74,17 +76,19 @@ class KeybindingService {
         const key = parts.pop()
         if (!key) return false
 
-        const meta = parts.includes('meta') || parts.includes('cmd') || parts.includes('command')
-        const ctrl = parts.includes('ctrl') || parts.includes('control')
+        const hasMeta = parts.includes('meta') || parts.includes('cmd') || parts.includes('command')
+        const hasCtrl = parts.includes('ctrl') || parts.includes('control')
         const shift = parts.includes('shift')
         const alt = parts.includes('alt') || parts.includes('option')
 
-        // 修饰键匹配
+        // macOS: Ctrl 在绑定定义中映射到 Command (metaKey)
+        const meta = isMac ? (hasCtrl || hasMeta) : hasMeta
+        const ctrl = isMac ? false : hasCtrl
+
         const modifiersMatch =
             (e.metaKey === meta) &&
             (e.ctrlKey === ctrl) &&
             (e.altKey === alt)
-        // Shift 单独检查：如果绑定不需要 Shift，但用户按了 Shift，也不匹配
         const shiftMatch = shift || !e.shiftKey
 
         // 按键匹配（忽略大小写）
@@ -170,3 +174,32 @@ class KeybindingService {
 }
 
 export const keybindingService = new KeybindingService()
+
+/**
+ * 根据平台转换快捷键显示文本
+ * macOS: Ctrl→⌘  Alt→⌥  Shift→⇧  Backquote→`
+ */
+export function formatShortcut(shortcut: string): string {
+    if (!isMac) return shortcut
+    return shortcut
+        .replace(/Ctrl\+/gi, '⌘')
+        .replace(/Alt\+/gi, '⌥')
+        .replace(/Shift\+/gi, '⇧')
+}
+
+/**
+ * 将快捷键字符串拆分为适合 macOS 显示的按键数组
+ * macOS: Ctrl→⌘  Alt→⌥  Shift→⇧
+ */
+export function formatShortcutKeys(keys: string[]): string[] {
+    if (!isMac) return keys
+    return keys.map(k => {
+        const lower = k.toLowerCase()
+        if (lower === 'ctrl') return '⌘'
+        if (lower === 'alt') return '⌥'
+        if (lower === 'shift') return '⇧'
+        return k
+    })
+}
+
+export { isMac }


### PR DESCRIPTION
问题：项目全局快捷键仅检测 e.ctrlKey（物理 Ctrl 键），
macOS 用户习惯使用 Command 键（e.metaKey），导致 ⌘S 保存、
⌘P 快速打开等常用快捷键全部失效。

修复内容：
- keybindingService: matches() 在 macOS 上将 Ctrl 绑定映射到 Command 键（metaKey），新增 formatShortcut/formatShortcutKeys 工具函数用于 UI 显示自动转换（Ctrl→⌘, Alt→⌥, Shift→⇧）
- useGlobalShortcuts: 全局快捷键 Hook 使用平台感知的修饰键检测
- TerminalManager: 终端复制粘贴支持 ⌘C/⌘V
- KeybindingPanel: 录制快捷键时 macOS Command 键正确映射
- 所有 UI 组件（CommandPalette、KeyboardShortcuts、TabContextMenu、 EditorContextMenu、TerminalPanel、ActivityBar、WelcomePage） 中的快捷键提示在 macOS 上自动显示为 ⌘ 符号