### PR TITLE
fix: avoid macOS agent terminal PTY crashes

### DIFF
--- a/src/main/security/secureTerminal.ts
+++ b/src/main/security/secureTerminal.ts
@@ -802,8 +802,10 @@ export function registerSecureTerminalHandlers(
     const mainWindow = getMainWindow()
     const workspace = getWorkspace(event)
     const { id, cwd, shell, backend = 'pty', remote } = options
+    const effectiveBackend: TerminalBackend =
+      process.platform === 'darwin' && !remote?.host ? 'pipe' : backend
 
-    if (backend === 'pty' && !pty) {
+    if (effectiveBackend === 'pty' && !pty) {
       return { success: false, error: 'node-pty not available' }
     }
 
@@ -851,12 +853,12 @@ export function registerSecureTerminalHandlers(
         }) || '/bin/bash'
 
         logger.security.info(`[Terminal] Using shell: ${shellPath}`)
-        shellArgs = backend === 'pipe' ? ['-il'] : ['-l']
+        shellArgs = effectiveBackend === 'pipe' ? ['-il'] : ['-l']
       } else {
         shellPath = process.env.SHELL || '/bin/bash'
       }
 
-      logger.security.info(`[Terminal] Spawning ${backend.toUpperCase()} terminal: ${shellPath} ${shellArgs.join(' ')} in ${targetCwd}`)
+      logger.security.info(`[Terminal] Spawning ${effectiveBackend.toUpperCase()} terminal: ${shellPath} ${shellArgs.join(' ')} in ${targetCwd}`)
 
       const fs = require('fs')
       const pathModule = require('path')
@@ -885,7 +887,7 @@ export function registerSecureTerminalHandlers(
           logger.security.error(`[Terminal] Remote SSH spawn failed: ${errorMsg}`, err)
           return { success: false, error: `Failed to connect remote shell: ${errorMsg}` }
         }
-      } else if (backend === 'pipe') {
+      } else if (effectiveBackend === 'pipe') {
         const child = spawn(shellPath, shellArgs, {
           cwd: targetCwd,
           env: {
@@ -948,11 +950,11 @@ export function registerSecureTerminalHandlers(
         id,
         cwd: targetCwd,
         shell: shellPath,
-        backend: remote?.host ? 'ssh2' : backend,
+        backend: remote?.host ? 'ssh2' : effectiveBackend,
         remoteHost: remote?.host,
       })
 
-      logger.security.info(`[Terminal] Created ${remote?.host ? 'ssh2' : backend} terminal ${id} with shell ${shellPath}`)
+      logger.security.info(`[Terminal] Created ${remote?.host ? 'ssh2' : effectiveBackend} terminal ${id} with shell ${shellPath}`)
       return { success: true }
     } catch (err) {
       logger.security.error('[Terminal] Failed to create terminal:', err)

--- a/src/renderer/services/TerminalManager.ts
+++ b/src/renderer/services/TerminalManager.ts
@@ -18,6 +18,7 @@ import { getEditorConfig } from "@renderer/settings";
 import { logger } from "@utils/Logger";
 import { toAppError } from "@shared/utils/errorHandler";
 import { isMac } from "@services/keybindingService";
+import { getInteractiveTerminalBackend } from "@/renderer/agent/tools/commandRuntime";
 
 // ===== 类型定义 =====
 
@@ -302,6 +303,9 @@ class TerminalManagerClass {
     remote?: TerminalInstance['remote'];
   }): Promise<string> {
     const id = crypto.randomUUID();
+    const backend =
+      options.backend ??
+      (options.isAgent ? getInteractiveTerminalBackend() : 'pty');
 
     const instance: TerminalInstance = {
       id,
@@ -319,7 +323,7 @@ class TerminalManagerClass {
     this.notify();
 
     // 创建 PTY
-    const ptyPromise = this.createPty(id, options.cwd, options.shell, options.backend, options.remote);
+    const ptyPromise = this.createPty(id, options.cwd, options.shell, backend, options.remote);
     this.pendingPtyCreation.set(id, ptyPromise);
 
     try {

--- a/tests/main/security/secureTerminal.test.ts
+++ b/tests/main/security/secureTerminal.test.ts
@@ -1,0 +1,117 @@
+import { EventEmitter } from 'events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handlers = new Map<string, Function>()
+const childSpawnMock = vi.fn()
+const ptySpawnMock = vi.fn()
+
+vi.mock('electron', () => ({
+  BrowserWindow: class MockBrowserWindow {},
+  ipcMain: {
+    on: vi.fn(),
+  },
+}))
+
+vi.mock('child_process', () => ({
+  spawn: childSpawnMock,
+  execSync: vi.fn(),
+  execFile: vi.fn(),
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: ptySpawnMock,
+}))
+
+vi.mock('@shared/utils/Logger', () => ({
+  logger: {
+    security: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@shared/utils/errorHandler', () => ({
+  toAppError: (err: unknown) => err instanceof Error ? err : new Error(String(err)),
+}))
+
+vi.mock('@main/ipc/safeHandle', () => ({
+  safeIpcHandle: vi.fn((channel: string, handler: Function) => {
+    handlers.set(channel, handler)
+  }),
+}))
+
+vi.mock('@main/security/securityModule', () => ({
+  OperationType: {
+    TERMINAL_INTERACTIVE: 'terminal:interactive',
+    SHELL_EXECUTE: 'shell:execute',
+    GIT_EXEC: 'git:execute',
+  },
+  securityManager: {
+    validateWorkspacePath: vi.fn(() => true),
+    logOperation: vi.fn(),
+    checkPermission: vi.fn(async () => true),
+  },
+}))
+
+describe('secureTerminal', () => {
+  beforeEach(() => {
+    handlers.clear()
+    childSpawnMock.mockReset()
+    ptySpawnMock.mockReset()
+  })
+
+  afterEach(async () => {
+    const module = await import('@main/security/secureTerminal')
+    module.cleanupTerminals()
+    vi.restoreAllMocks()
+  })
+
+  it('falls back to pipe on macOS even when PTY backend is requested', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+
+    const stdout = new EventEmitter()
+    const stderr = new EventEmitter()
+    const stdin = { destroyed: false, write: vi.fn() }
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter
+      stderr: EventEmitter
+      stdin: typeof stdin
+      killed: boolean
+      pid?: number
+      kill: ReturnType<typeof vi.fn>
+    }
+    child.stdout = stdout
+    child.stderr = stderr
+    child.stdin = stdin
+    child.killed = false
+    child.pid = 12345
+    child.kill = vi.fn(() => {
+      child.killed = true
+      return true
+    })
+
+    childSpawnMock.mockReturnValue(child)
+
+    const module = await import('@main/security/secureTerminal')
+    module.registerSecureTerminalHandlers(
+      () => ({ isDestroyed: () => false, webContents: { send: vi.fn() } }) as any,
+      () => ({ roots: ['/Users/tech/Documents/dev/NodeProj/Adnify'] }),
+    )
+
+    const handler = handlers.get('terminal:interactive')
+    expect(handler).toBeTypeOf('function')
+
+    const result = await handler?.({}, {
+      id: 'agent-test',
+      cwd: '/Users/tech/Documents/dev/NodeProj/Adnify',
+      backend: 'pty',
+    })
+
+    expect(result).toEqual({ success: true })
+    expect(childSpawnMock).toHaveBeenCalledTimes(1)
+    expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/TerminalManager.test.ts
+++ b/tests/services/TerminalManager.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createMock = vi.fn()
+const onDataCleanup = vi.fn()
+const onExitCleanup = vi.fn()
+const onErrorCleanup = vi.fn()
+
+vi.mock('@renderer/services/electronAPI', () => ({
+  api: {
+    terminal: {
+      create: createMock,
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      onData: vi.fn(() => onDataCleanup),
+      onExit: vi.fn(() => onExitCleanup),
+      onError: vi.fn(() => onErrorCleanup),
+    },
+  },
+}))
+
+vi.mock('@renderer/settings', () => ({
+  getEditorConfig: () => ({
+    performance: {
+      terminalBufferSize: 1000,
+    },
+  }),
+}))
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class MockTerminal {
+    options: Record<string, unknown> = {}
+    write = vi.fn()
+    focus = vi.fn()
+    loadAddon = vi.fn()
+    open = vi.fn()
+    dispose = vi.fn()
+    onData = vi.fn()
+    onResize = vi.fn()
+  },
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class MockFitAddon {
+    fit = vi.fn()
+    dispose = vi.fn()
+  },
+}))
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: class MockWebLinksAddon {},
+}))
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: class MockWebglAddon {
+    dispose = vi.fn()
+    onContextLoss = vi.fn()
+  },
+}))
+
+vi.mock('@utils/Logger', () => ({
+  logger: {
+    system: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@services/keybindingService', () => ({
+  isMac: true,
+}))
+
+vi.mock('@renderer/agent/tools/commandRuntime', () => ({
+  getInteractiveTerminalBackend: vi.fn(() => 'pipe'),
+}))
+
+describe('TerminalManager', () => {
+  beforeEach(() => {
+    createMock.mockReset()
+    createMock.mockResolvedValue({ success: true })
+  })
+
+  it('uses pipe backend for agent terminals on macOS', async () => {
+    const { terminalManager } = await import('@renderer/services/TerminalManager')
+
+    try {
+      await terminalManager.getOrCreateAgentTerminal('/tmp/adnify-agent')
+
+      expect(createMock).toHaveBeenCalledTimes(1)
+      expect(createMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/tmp/adnify-agent',
+          backend: 'pipe',
+        }),
+      )
+    } finally {
+      terminalManager.cleanup()
+    }
+  })
+})


### PR DESCRIPTION
概要
本次 PR 修复了 macOS 上 Agent 创建终端时误走 node-pty 路径，进而触发 PtyFork(...) -> SIGABRT 崩溃的问题。

问题原因
根据崩溃报告，应用在主线程中崩溃于 node-pty 的原生模块调用：

PtyFork(Napi::CallbackInfo const&)
abort()
SIGABRT
根因是 Agent 终端在 macOS 上本应使用 pipe 后端以避免 PTY 原生调用，但实际创建链路中没有正确把这一策略传递到底层，导致仍然进入了 pty.spawn()，最终触发崩溃。

修改内容
在渲染层补充兜底逻辑：
Agent 终端在未显式指定 backend 时，自动使用平台对应的安全后端
macOS 下默认使用 pipe，不再默认落到 pty
在主进程增加二次保护：
即使上层传入 backend: 'pty'
在 macOS 本地终端场景下仍强制降级为 pipe
增加回归测试，覆盖渲染层和主进程两条关键路径，防止后续回归
涉及文件
src/renderer/services/TerminalManager.ts
src/main/security/secureTerminal.ts
tests/services/TerminalManager.test.ts
tests/main/security/secureTerminal.test.ts