### PR TITLE
fix: restore packaged LSP installs and definition navigation

### DIFF
--- a/src/main/ipc/lsp.ts
+++ b/src/main/ipc/lsp.ts
@@ -17,6 +17,13 @@ import {
 } from '../lsp/installer'
 import { lspUriToPath } from '@shared/utils/uriUtils'
 
+function getFallbackRoot(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, '/')
+  const lastSlash = normalized.lastIndexOf('/')
+  if (lastSlash <= 0) return normalized || '/'
+  return normalized.slice(0, lastSlash)
+}
+
 function getLanguageId(filePath: string): LanguageId | null {
   const ext = filePath.split('.').pop()?.toLowerCase() || ''
   const lang = EXTENSION_TO_LANGUAGE[ext]
@@ -31,12 +38,13 @@ function getLanguageIdFromUri(uri: string): string {
 
 async function getServerForUri(uri: string, workspacePath: string): Promise<string | null> {
   const filePath = lspUriToPath(uri)
+  const effectiveWorkspacePath = workspacePath || getFallbackRoot(filePath)
 
   const languageId = getLanguageId(filePath)
   if (!languageId) return null
 
   // 使用智能根目录检测启动服务器
-  return lspManager.ensureServerForFile(filePath, languageId, workspacePath)
+  return lspManager.ensureServerForFile(filePath, languageId, effectiveWorkspacePath)
 }
 
 // preferencesStore 引用，用于保存 LSP 配置
@@ -70,7 +78,14 @@ export function registerLspHandlers(preferencesStore?: any): void {
 
   ipcMain.handle('lsp:didOpen', async (_, params: { uri: string; languageId: string; version: number; text: string; workspacePath?: string }) => {
     const serverName = await getServerForUri(params.uri, params.workspacePath || '')
-    if (!serverName) return
+    if (!serverName) {
+      logger.lsp.warn('[LSP IPC] didOpen skipped: no server available', {
+        uri: params.uri,
+        languageId: params.languageId,
+        workspacePath: params.workspacePath || '',
+      })
+      return { success: false, serverName: null }
+    }
 
     // 跟踪文档打开状态
     lspManager.trackDocumentOpen(serverName, params.uri, params.languageId, params.version, params.text)
@@ -78,6 +93,7 @@ export function registerLspHandlers(preferencesStore?: any): void {
     lspManager.sendNotification(serverName, 'textDocument/didOpen', {
       textDocument: { uri: params.uri, languageId: params.languageId, version: params.version, text: params.text },
     })
+    return { success: true, serverName }
   })
 
   ipcMain.handle('lsp:didChange', async (_, params: { uri: string; version: number; text: string; workspacePath?: string }) => {

--- a/src/main/lsp/installer.ts
+++ b/src/main/lsp/installer.ts
@@ -63,6 +63,14 @@ export function getLspBinDir(): string {
   return dir
 }
 
+function getCandidateLspBinDirs(): string[] {
+  const configuredDir = getLspBinDir()
+  if (configuredDir === DEFAULT_LSP_BIN_DIR) {
+    return [configuredDir]
+  }
+  return [configuredDir, DEFAULT_LSP_BIN_DIR]
+}
+
 /**
  * 获取默认 LSP 服务器安装目录
  */
@@ -90,19 +98,67 @@ function logEnvironmentInfo(): void {
   })
 }
 
+function getCommonBinaryDirs(): string[] {
+  if (process.platform === 'win32') {
+    return [
+      'C:\\Program Files\\nodejs',
+      'C:\\Program Files (x86)\\nodejs',
+    ]
+  }
+
+  return [
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    '/opt/local/bin',
+    '/usr/bin',
+    '/bin',
+  ]
+}
+
+function getAugmentedPathEnv(): string {
+  const existing = (process.env.PATH || '').split(path.delimiter).filter(Boolean)
+  const merged = [...existing, ...getCommonBinaryDirs()]
+  return Array.from(new Set(merged)).join(path.delimiter)
+}
+
+function resolveCommandPath(cmd: string): string | null {
+  if (!cmd) return null
+
+  if (path.isAbsolute(cmd) && fs.existsSync(cmd)) {
+    return cmd
+  }
+
+  const searchDirs = getAugmentedPathEnv().split(path.delimiter).filter(Boolean)
+  const executableCandidates = process.platform === 'win32'
+    ? Array.from(new Set([cmd, `${cmd}.cmd`, `${cmd}.exe`, `${cmd}.bat`]))
+    : [cmd]
+
+  for (const dir of searchDirs) {
+    for (const candidate of executableCandidates) {
+      const fullPath = path.join(dir, candidate)
+      if (fs.existsSync(fullPath)) {
+        return fullPath
+      }
+    }
+  }
+
+  return null
+}
+
 /**
  * 检查命令是否存在于 PATH 中
  */
 export function commandExists(cmd: string): boolean {
   try {
+    const env = { ...process.env, PATH: getAugmentedPathEnv() }
     if (process.platform === 'win32') {
-      execSync(`where ${cmd}`, { stdio: 'ignore' })
+      execSync(`where ${cmd}`, { stdio: 'ignore', env })
     } else {
-      execSync(`which ${cmd}`, { stdio: 'ignore' })
+      execSync(`which ${cmd}`, { stdio: 'ignore', env })
     }
     return true
   } catch {
-    return false
+    return resolveCommandPath(cmd) !== null
   }
 }
 
@@ -112,15 +168,21 @@ export function commandExists(cmd: string): boolean {
 async function npmInstall(packageNames: string | string[], targetDir: string): Promise<boolean> {
   return new Promise((resolve) => {
     const npmCmd = getNpmCommand()
+    const resolvedNpmCmd = resolveCommandPath(npmCmd) || resolveCommandPath('npm')
     const packages = Array.isArray(packageNames) ? packageNames : [packageNames]
-    const installArgs = ['install', ...packages, '--prefix', targetDir]
+    const installArgs = ['install', ...packages, '--no-save', '--no-package-lock']
+    const env = {
+      ...process.env,
+      PATH: getAugmentedPathEnv(),
+    }
 
     logger.lsp.info(`[LSP Installer] Running: npm install ${packages.join(' ')} in ${targetDir}`)
-    logger.lsp.debug(`[LSP Installer] npm command: ${npmCmd}`)
+    logger.lsp.debug(`[LSP Installer] npm command: ${resolvedNpmCmd || npmCmd}`)
     logger.lsp.debug('[LSP Installer] npm args:', installArgs)
+    logger.lsp.debug(`[LSP Installer] npm cwd: ${targetDir}`)
 
     // 检查 npm 是否可用
-    if (!commandExists('npm')) {
+    if (!resolvedNpmCmd) {
       logger.lsp.error('[LSP Installer] npm not found in PATH')
       resolve(false)
       return
@@ -138,9 +200,10 @@ async function npmInstall(packageNames: string | string[], targetDir: string): P
       }
     }
 
-    const proc = spawn(npmCmd, installArgs, {
+    const proc = spawn(resolvedNpmCmd, installArgs, {
       cwd: targetDir,
       stdio: 'pipe',
+      env,
     })
 
     let stdout = ''
@@ -180,7 +243,7 @@ async function npmInstall(packageNames: string | string[], targetDir: string): P
         error: err.message,
         packageNames: packages,
         targetDir,
-        npmCmd,
+        npmCmd: resolvedNpmCmd,
       })
       resolve(false)
     })
@@ -519,26 +582,26 @@ export function getInstalledServerPath(serverType: string): string | null {
   const config = SERVER_PATHS[serverType]
   if (!config) return null
 
-  const binDir = getLspBinDir()
-
   // 1. 检查用户安装目录
-  for (const p of config.userPaths) {
-    // 处理通配符路径（如 clangd_*/bin/clangd）
-    if (p.includes('*')) {
-      const [prefix] = p.split('*')
-      const parentDir = path.join(binDir, path.dirname(prefix))
-      if (fs.existsSync(parentDir)) {
-        const entries = fs.readdirSync(parentDir)
-        for (const entry of entries) {
-          if (entry.startsWith(path.basename(prefix))) {
-            const fullPath = path.join(parentDir, entry, p.split('*/')[1] || '')
-            if (fs.existsSync(fullPath)) return fullPath
+  for (const binDir of getCandidateLspBinDirs()) {
+    for (const p of config.userPaths) {
+      // 处理通配符路径（如 clangd_*/bin/clangd）
+      if (p.includes('*')) {
+        const [prefix] = p.split('*')
+        const parentDir = path.join(binDir, path.dirname(prefix))
+        if (fs.existsSync(parentDir)) {
+          const entries = fs.readdirSync(parentDir)
+          for (const entry of entries) {
+            if (entry.startsWith(path.basename(prefix))) {
+              const fullPath = path.join(parentDir, entry, p.split('*/')[1] || '')
+              if (fs.existsSync(fullPath)) return fullPath
+            }
           }
         }
+      } else {
+        const fullPath = path.join(binDir, p)
+        if (fs.existsSync(fullPath)) return fullPath
       }
-    } else {
-      const fullPath = path.join(binDir, p)
-      if (fs.existsSync(fullPath)) return fullPath
     }
   }
 

--- a/src/renderer/components/editor/EditorContextMenu.tsx
+++ b/src/renderer/components/editor/EditorContextMenu.tsx
@@ -171,6 +171,7 @@ export default function EditorContextMenu({ x, y, editor, onClose }: EditorConte
         filePath,
         position.lineNumber - 1,
         position.column - 1,
+        model.getValue(),
       )
     } catch {
       // 与 F12 保持一致：对不可访问定义静默忽略

--- a/src/renderer/components/editor/hooks/useEditorActions.ts
+++ b/src/renderer/components/editor/hooks/useEditorActions.ts
@@ -25,10 +25,11 @@ export async function navigateToDefinition(
   editorInstance: editor.IStandaloneCodeEditor,
   filePath: string,
   line: number,   // LSP 0-indexed
-  col: number     // LSP 0-indexed
-  ) {
-    const locations = await goToDefinition(filePath, line, col)
-    if (!locations || locations.length === 0) return
+  col: number,    // LSP 0-indexed
+  documentText?: string
+) {
+  const locations = await goToDefinition(filePath, line, col, documentText)
+  if (!locations || locations.length === 0) return
 
   const loc = locations[0]
   const targetPath = lspUriToPath(loc.uri)
@@ -136,7 +137,12 @@ export function useEditorActions(
         const filePath = lspUriToPath(model.uri.toString())
 
         try {
-          const locations = await goToDefinition(filePath, position.lineNumber - 1, position.column - 1)
+          const locations = await goToDefinition(
+            filePath,
+            position.lineNumber - 1,
+            position.column - 1,
+            model.getValue()
+          )
           const hasDefinition = !!locations && locations.length > 0
           definitionAvailabilityCache.set(probeKey, hasDefinition)
 
@@ -235,7 +241,8 @@ export function useEditorActions(
       try {
         await navigateToDefinition(
           editorInstance, filePath,
-          position.lineNumber - 1, position.column - 1
+          position.lineNumber - 1, position.column - 1,
+          model.getValue()
         )
       } catch { /* 静默忽略，如 stdlib 等不可访问路径 */ }
     })
@@ -256,7 +263,8 @@ export function useEditorActions(
       try {
         await navigateToDefinition(
           editorInstance, filePath,
-          e.target.position.lineNumber - 1, e.target.position.column - 1
+          e.target.position.lineNumber - 1, e.target.position.column - 1,
+          model.getValue()
         )
       } catch { /* 静默忽略 */ }
     })

--- a/src/renderer/hooks/useLspIntegration.ts
+++ b/src/renderer/hooks/useLspIntegration.ts
@@ -188,10 +188,12 @@ export function useLspIntegration() {
 
   // 通知 LSP 文件已打开
   const notifyFileOpened = useCallback((filePath: string, content: string) => {
-    if (isLspReady) {
-      didOpenDocument(filePath, content)
-    }
-  }, [isLspReady])
+    void didOpenDocument(filePath, content).then((success) => {
+      if (success && !useStore.getState().isLspReady) {
+        setIsLspReady(true)
+      }
+    })
+  }, [setIsLspReady])
 
   return {
     isLspReady,

--- a/src/renderer/services/lspProviders.ts
+++ b/src/renderer/services/lspProviders.ts
@@ -138,7 +138,8 @@ export function registerLspProviders(monaco: typeof Monaco) {
       const result = await goToDefinition(
         filePath,
         position.lineNumber - 1,
-        position.column - 1
+        position.column - 1,
+        model.getValue()
       )
       if (!result || result.length === 0) return null
       return result.map((loc: any) => ({

--- a/src/renderer/services/lspService.ts
+++ b/src/renderer/services/lspService.ts
@@ -14,6 +14,13 @@ import { pathToLspUri } from '@shared/utils/uriUtils'
 const documentVersions = new Map<string, number>()
 const openedDocuments = new Set<string>()
 
+function getFileDirectory(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, '/')
+  const lastSlash = normalized.lastIndexOf('/')
+  if (lastSlash <= 0) return normalized || '/'
+  return normalized.slice(0, lastSlash)
+}
+
 // ===== 内部辅助函数 =====
 
 /**
@@ -100,7 +107,7 @@ async function executeLspPositionRequest<T>(
  */
 export function getFileWorkspaceRoot(filePath: string): string | null {
   const { workspace } = useStore.getState()
-  if (!workspace || workspace.roots.length === 0) return null
+  if (!workspace || workspace.roots.length === 0) return getFileDirectory(filePath)
 
   // 找到最长匹配的根目录（处理嵌套情况）
   const normalizedPath = filePath.replace(/\\/g, '/')
@@ -115,7 +122,7 @@ export function getFileWorkspaceRoot(filePath: string): string | null {
     }
   }
 
-  return bestMatch || workspace.roots[0]
+  return bestMatch || workspace.roots[0] || getFileDirectory(filePath)
 }
 
 /**
@@ -175,22 +182,19 @@ export function resetLspState(): void {
  * 通知服务器文档已打开
  * 使用智能根目录检测来启动正确的 LSP 服务器
  */
-export async function didOpenDocument(filePath: string, content: string): Promise<void> {
+export async function didOpenDocument(filePath: string, content: string): Promise<boolean> {
   const uri = pathToLspUri(filePath)
   const languageId = getLanguageId(filePath)
   if (!isLanguageSupported(languageId)) {
-    return
+    return false
   }
 
   if (openedDocuments.has(uri)) {
     await didChangeDocument(filePath, content)
-    return
+    return true
   }
 
   const version = 1
-  documentVersions.set(uri, version)
-  openedDocuments.add(uri)
-
   const workspacePath = getFileWorkspaceRoot(filePath)
 
   // 使用智能根目录检测启动服务器
@@ -202,7 +206,19 @@ export async function didOpenDocument(filePath: string, content: string): Promis
     text: content,
     workspacePath,
   }
-  await api.lsp.didOpen(params)
+  const result = await api.lsp.didOpen(params)
+  if (!result?.success) {
+    logger.lsp.warn('[LSP] didOpen failed or server unavailable', {
+      filePath,
+      uri,
+      languageId,
+      workspacePath,
+    })
+    return false
+  }
+
+  documentVersions.set(uri, version)
+  openedDocuments.add(uri)
 
   // 为 Pyright 发送一个 didChange 来触发诊断
   if (languageId === 'python') {
@@ -210,6 +226,8 @@ export async function didOpenDocument(filePath: string, content: string): Promis
       didChangeDocument(filePath, content)
     }, 100)
   }
+
+  return true
 }
 
 /**
@@ -275,11 +293,15 @@ export async function didSaveDocument(filePath: string, content?: string): Promi
 export async function goToDefinition(
   filePath: string,
   line: number,
-  character: number
+  character: number,
+  documentText?: string
 ): Promise<{ uri: string; range: any }[] | null> {
   return executeLspPositionRequest(
     filePath, line, character,
     async (params) => {
+      if (typeof documentText === 'string') {
+        await didOpenDocument(filePath, documentText)
+      }
       logger.lsp.info('[LSP] Go to definition request:', {
         filePath,
         uri: params.uri,


### PR DESCRIPTION
## Summary
- fix packaged LSP install path and npm lookup behavior
- restore go-to-definition and modifier-hover navigation in packaged builds
- add workspace/document fallback handling for LSP requests

## Testing
- npm run build
- npm run pack
