### PR TITLE
feat(Editor): implement scroll position restoration and saving for open files

### DIFF
--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -87,6 +87,8 @@ export default function Editor() {
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
   const monacoRef = useRef<typeof import('monaco-editor') | typeof import('monaco-editor/esm/vs/editor/editor.api') | null>(null)
   const cursorDebounceRef = useRef<NodeJS.Timeout | null>(null)
+  const isRestoringScrollRef = useRef(false)
+  const setFileScrollPosition = useStore((state) => state.setFileScrollPosition)
 
   // Hooks
   const { registerProviders, setupDiagnostics, setupLinkNavigation, notifyFileOpened } = useLspIntegration()
@@ -134,6 +136,7 @@ export default function Editor() {
       }
     }
   }, [activeFilePath, activeFile, clearLintErrors, notifyFileOpened, isPreviewDocument])
+
   // 清理不再打开的文件的 Monaco Models，防止内存泄漏
   useEffect(() => {
     if (!monacoRef.current) return
@@ -190,6 +193,7 @@ export default function Editor() {
     editorRef.current = editor
     monacoRef.current = monacoInstance
     const disposables: { dispose: () => void }[] = []
+    const currentFilePath = activeFilePath
 
     setupCursorTracking(editor, cursorDebounceRef)
     registerProviders(monacoInstance)
@@ -200,28 +204,50 @@ export default function Editor() {
 
     monacoInstance.editor.setTheme('adnify-dynamic')
 
+    // 恢复文件视图状态
+    if (currentFilePath) {
+      const { openFiles } = useStore.getState()
+      const file = openFiles.find(f => f.path === currentFilePath)
+      if (file?.scrollPosition && typeof editor.restoreViewState === 'function') {
+        try {
+          editor.restoreViewState(file.scrollPosition as any)
+        } catch (e) {
+          // ignore restore errors
+        }
+      }
+    }
+
+    // 监听滚动变化并保存视图状态
+    const scrollDisposable = editor.onDidScrollChange(() => {
+      if (currentFilePath && typeof editor.saveViewState === 'function') {
+        const state = editor.saveViewState()
+        setFileScrollPosition(currentFilePath, state as any)
+      }
+    })
+    disposables.push(scrollDisposable)
+
     // 监听内容变化，基于版本号更新 dirty 状态
     const model = editor.getModel()
-    if (model && activeFilePath) {
+    if (model && currentFilePath) {
       // 初始化时记录版本号
       const { openFiles } = useStore.getState()
-      const file = openFiles.find(f => f.path === activeFilePath)
+      const file = openFiles.find(f => f.path === currentFilePath)
       if (file && !file.savedVersionId) {
         // 首次打开，记录初始版本号
         const { markFileSaved } = useStore.getState()
-        markFileSaved(activeFilePath, model.getAlternativeVersionId())
+        markFileSaved(currentFilePath, model.getAlternativeVersionId())
       }
 
       const contentDisposable = editor.onDidChangeModelContent(() => {
         const currentVersionId = model.getAlternativeVersionId()
         const editorContent = editor.getValue()
         const { openFiles: currentFiles } = useStore.getState()
-        const currentFile = currentFiles.find(f => f.path === activeFilePath)
+        const currentFile = currentFiles.find(f => f.path === currentFilePath)
 
         if (currentFile && editorContent === currentFile.content) {
-          markFileSaved(activeFilePath, currentVersionId)
+          markFileSaved(currentFilePath, currentVersionId)
         } else {
-          updateFileDirtyState(activeFilePath, currentVersionId)
+          updateFileDirtyState(currentFilePath, currentVersionId)
         }
       })
       disposables.push(contentDisposable)

--- a/src/renderer/components/sidebar/panels/ExplorerView.tsx
+++ b/src/renderer/components/sidebar/panels/ExplorerView.tsx
@@ -8,7 +8,7 @@ import { FolderOpen, Plus, RefreshCw, FolderPlus, GitBranch, FilePlus, ExternalL
 import { useStore } from '@store'
 import { useShallow } from 'zustand/react/shallow'
 import { t } from '@renderer/i18n'
-import { getDirPath, joinPath, pathStartsWith } from '@shared/utils/pathUtils'
+import { getDirPath, joinPath, pathStartsWith, pathEquals } from '@shared/utils/pathUtils'
 import { gitService } from '@renderer/services/gitService'
 import { getEditorConfig } from '@renderer/settings'
 import { toast } from '../../common/ToastProvider'
@@ -117,6 +117,7 @@ export function ExplorerView() {
     const shouldRefreshRoot = shouldResetTree
       || options?.refreshRoot === true
       || affectedPaths.some(path => path === workspacePath)
+      || deletedPaths.some(path => pathEquals(getDirPath(path), workspacePath))
 
     if (shouldResetTree) {
       directoryCacheService.clear()
@@ -340,7 +341,7 @@ export function ExplorerView() {
       onClick: handlePasteToWorkspaceRoot,
     },
     { id: 'sepPaste', label: '', separator: true },
-    { id: 'refresh', label: t('refresh', 'zh'), icon: RefreshCw, onClick: () => refreshFiles({ resetTree: true, refreshRoot: true }) },
+    { id: 'refresh', label: t('refresh', 'zh'), icon: RefreshCw, onClick: () => refreshFiles({ refreshRoot: true }) },
     {
       id: 'reveal',
       label: '在资源管理器中显示',
@@ -372,7 +373,7 @@ export function ExplorerView() {
             </button>
           </Tooltip>
           <Tooltip content={t('refresh', language)}>
-            <button onClick={() => refreshFiles({ resetTree: true, refreshRoot: true })} className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-white/5 text-text-muted hover:text-text-primary transition-all active:scale-90">
+            <button onClick={() => refreshFiles({ refreshRoot: true })} className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-white/5 text-text-muted hover:text-text-primary transition-all active:scale-90">
               <RefreshCw className="w-3.5 h-3.5" />
             </button>
           </Tooltip>

--- a/src/renderer/components/sidebar/panels/ExplorerView.tsx
+++ b/src/renderer/components/sidebar/panels/ExplorerView.tsx
@@ -4,6 +4,7 @@
 
 import { api } from '@/renderer/services/electronAPI'
 import { useState, useEffect, useCallback } from 'react'
+import type { MouseEvent } from 'react'
 import { FolderOpen, Plus, RefreshCw, FolderPlus, GitBranch, FilePlus, ExternalLink, Crosshair, Terminal, Clipboard } from 'lucide-react'
 import { useStore } from '@store'
 import { useShallow } from 'zustand/react/shallow'
@@ -23,6 +24,7 @@ import { formatShortcut } from '@/renderer/services/keybindingService'
 
 export interface TreeRefreshOptions {
   resetTree?: boolean
+  refreshAll?: boolean
   affectedPaths?: string[]
   deletedPaths?: string[]
   refreshRoot?: boolean
@@ -114,11 +116,16 @@ export function ExplorerView() {
     const affectedPaths = Array.from(new Set(options?.affectedPaths?.filter(Boolean) ?? []))
     const deletedPaths = Array.from(new Set(options?.deletedPaths?.filter(Boolean) ?? []))
     const shouldResetTree = options?.resetTree === true
+    const shouldRefreshAll = options?.refreshAll === true
     const shouldRefreshRoot = shouldResetTree
+      || shouldRefreshAll
       || options?.refreshRoot === true
       || affectedPaths.some(path => path === workspacePath)
 
     if (shouldResetTree) {
+      directoryCacheService.clear()
+    } else if (shouldRefreshAll) {
+      // refreshAll: 清除缓存但不重置树版本，保留展开状态
       directoryCacheService.clear()
     } else {
       affectedPaths.forEach(path => directoryCacheService.invalidate(path))
@@ -132,6 +139,16 @@ export function ExplorerView() {
 
     if (shouldResetTree) {
       setTreeVersion((version) => version + 1)
+    } else if (shouldRefreshAll) {
+      // 手动刷新时同时刷新根目录和所有已展开目录，但不要把根目录放进 affectedPaths，
+      // 否则 VirtualFileTree 会清掉根目录缓存后因为根目录始终处于 expanded 状态而重复请求。
+      const { expandedFolders } = useStore.getState() as { expandedFolders: Set<string> }
+      const expandedPaths = Array.from(expandedFolders).filter(path => path !== workspacePath) as string[]
+      setTreeRefreshSignal(prev => ({
+        tick: prev.tick + 1,
+        affectedPaths: expandedPaths,
+        deletedPaths: [],
+      }))
     } else if (affectedPaths.length > 0 || deletedPaths.length > 0) {
       setTreeRefreshSignal(prev => ({
         tick: prev.tick + 1,
@@ -294,9 +311,8 @@ export function ExplorerView() {
     },
     [workspacePath]
   )
-
   const handleRootContextMenu = useCallback(
-    (e: React.MouseEvent) => {
+    (e: MouseEvent) => {
       e.preventDefault()
       if (workspacePath) {
         setRootContextMenu({ x: e.clientX, y: e.clientY })
@@ -340,7 +356,7 @@ export function ExplorerView() {
       onClick: handlePasteToWorkspaceRoot,
     },
     { id: 'sepPaste', label: '', separator: true },
-    { id: 'refresh', label: t('refresh', 'zh'), icon: RefreshCw, onClick: () => refreshFiles({ resetTree: true, refreshRoot: true }) },
+    { id: 'refresh', label: t('refresh', 'zh'), icon: RefreshCw, onClick: () => refreshFiles({ refreshAll: true }) },
     {
       id: 'reveal',
       label: '在资源管理器中显示',
@@ -372,7 +388,7 @@ export function ExplorerView() {
             </button>
           </Tooltip>
           <Tooltip content={t('refresh', language)}>
-            <button onClick={() => refreshFiles({ resetTree: true, refreshRoot: true })} className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-white/5 text-text-muted hover:text-text-primary transition-all active:scale-90">
+            <button onClick={() => refreshFiles({ refreshAll: true })} className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-white/5 text-text-muted hover:text-text-primary transition-all active:scale-90">
               <RefreshCw className="w-3.5 h-3.5" />
             </button>
           </Tooltip>

--- a/src/renderer/components/sidebar/panels/ExplorerView.tsx
+++ b/src/renderer/components/sidebar/panels/ExplorerView.tsx
@@ -4,7 +4,6 @@
 
 import { api } from '@/renderer/services/electronAPI'
 import { useState, useEffect, useCallback } from 'react'
-import type { MouseEvent } from 'react'
 import { FolderOpen, Plus, RefreshCw, FolderPlus, GitBranch, FilePlus, ExternalLink, Crosshair, Terminal, Clipboard } from 'lucide-react'
 import { useStore } from '@store'
 import { useShallow } from 'zustand/react/shallow'
@@ -24,7 +23,6 @@ import { formatShortcut } from '@/renderer/services/keybindingService'
 
 export interface TreeRefreshOptions {
   resetTree?: boolean
-  refreshAll?: boolean
   affectedPaths?: string[]
   deletedPaths?: string[]
   refreshRoot?: boolean
@@ -116,16 +114,11 @@ export function ExplorerView() {
     const affectedPaths = Array.from(new Set(options?.affectedPaths?.filter(Boolean) ?? []))
     const deletedPaths = Array.from(new Set(options?.deletedPaths?.filter(Boolean) ?? []))
     const shouldResetTree = options?.resetTree === true
-    const shouldRefreshAll = options?.refreshAll === true
     const shouldRefreshRoot = shouldResetTree
-      || shouldRefreshAll
       || options?.refreshRoot === true
       || affectedPaths.some(path => path === workspacePath)
 
     if (shouldResetTree) {
-      directoryCacheService.clear()
-    } else if (shouldRefreshAll) {
-      // refreshAll: 清除缓存但不重置树版本，保留展开状态
       directoryCacheService.clear()
     } else {
       affectedPaths.forEach(path => directoryCacheService.invalidate(path))
@@ -139,16 +132,6 @@ export function ExplorerView() {
 
     if (shouldResetTree) {
       setTreeVersion((version) => version + 1)
-    } else if (shouldRefreshAll) {
-      // 手动刷新时同时刷新根目录和所有已展开目录，但不要把根目录放进 affectedPaths，
-      // 否则 VirtualFileTree 会清掉根目录缓存后因为根目录始终处于 expanded 状态而重复请求。
-      const { expandedFolders } = useStore.getState() as { expandedFolders: Set<string> }
-      const expandedPaths = Array.from(expandedFolders).filter(path => path !== workspacePath) as string[]
-      setTreeRefreshSignal(prev => ({
-        tick: prev.tick + 1,
-        affectedPaths: expandedPaths,
-        deletedPaths: [],
-      }))
     } else if (affectedPaths.length > 0 || deletedPaths.length > 0) {
       setTreeRefreshSignal(prev => ({
         tick: prev.tick + 1,
@@ -311,8 +294,9 @@ export function ExplorerView() {
     },
     [workspacePath]
   )
+
   const handleRootContextMenu = useCallback(
-    (e: MouseEvent) => {
+    (e: React.MouseEvent) => {
       e.preventDefault()
       if (workspacePath) {
         setRootContextMenu({ x: e.clientX, y: e.clientY })
@@ -356,7 +340,7 @@ export function ExplorerView() {
       onClick: handlePasteToWorkspaceRoot,
     },
     { id: 'sepPaste', label: '', separator: true },
-    { id: 'refresh', label: t('refresh', 'zh'), icon: RefreshCw, onClick: () => refreshFiles({ refreshAll: true }) },
+    { id: 'refresh', label: t('refresh', 'zh'), icon: RefreshCw, onClick: () => refreshFiles({ resetTree: true, refreshRoot: true }) },
     {
       id: 'reveal',
       label: '在资源管理器中显示',
@@ -388,7 +372,7 @@ export function ExplorerView() {
             </button>
           </Tooltip>
           <Tooltip content={t('refresh', language)}>
-            <button onClick={() => refreshFiles({ refreshAll: true })} className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-white/5 text-text-muted hover:text-text-primary transition-all active:scale-90">
+            <button onClick={() => refreshFiles({ resetTree: true, refreshRoot: true })} className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-white/5 text-text-muted hover:text-text-primary transition-all active:scale-90">
               <RefreshCw className="w-3.5 h-3.5" />
             </button>
           </Tooltip>

--- a/src/renderer/components/tree/VirtualFileTree.tsx
+++ b/src/renderer/components/tree/VirtualFileTree.tsx
@@ -197,21 +197,36 @@ export const VirtualFileTree = memo(function VirtualFileTree({
       let changed = false
       const next = new Map(prev)
 
-      refreshSignal.affectedPaths.forEach((path) => {
-        if (!expandedFolders.has(path)) {
-          if (next.has(path)) {
-            next.delete(path)
-            changed = true
-          }
-        }
-      })
-
+      // 对于 deletedPaths，从父目录的缓存子项中立即移除已删除的条目
+      // 这样删除的文件/文件夹会立刻从树中消失，无需等待异步刷新
       refreshSignal.deletedPaths.forEach((deletedPath) => {
+        // 清除已删除路径自身及其子目录的缓存
         for (const key of next.keys()) {
           if (pathEquals(key, deletedPath) || key.startsWith(`${deletedPath}/`) || key.startsWith(`${deletedPath}\\`)) {
             next.delete(key)
             changed = true
           }
+        }
+        // 从父目录的缓存子项数组中移除已删除的条目
+        const parentPath = getDirPath(deletedPath)
+        if (parentPath && next.has(parentPath)) {
+          const parentChildren = next.get(parentPath)!
+          const filtered = parentChildren.filter(
+            (child) => !pathEquals(child.path, deletedPath)
+          )
+          if (filtered.length !== parentChildren.length) {
+            next.set(parentPath, filtered)
+            changed = true
+          }
+        }
+      })
+
+      // 对于 affectedPaths，无论是否展开都先清除旧缓存
+      // 展开的目录会在下面异步重新加载
+      refreshSignal.affectedPaths.forEach((path) => {
+        if (next.has(path)) {
+          next.delete(path)
+          changed = true
         }
       })
 

--- a/src/renderer/components/tree/VirtualFileTree.tsx
+++ b/src/renderer/components/tree/VirtualFileTree.tsx
@@ -197,36 +197,21 @@ export const VirtualFileTree = memo(function VirtualFileTree({
       let changed = false
       const next = new Map(prev)
 
-      // 对于 deletedPaths，从父目录的缓存子项中立即移除已删除的条目
-      // 这样删除的文件/文件夹会立刻从树中消失，无需等待异步刷新
-      refreshSignal.deletedPaths.forEach((deletedPath) => {
-        // 清除已删除路径自身及其子目录的缓存
-        for (const key of next.keys()) {
-          if (pathEquals(key, deletedPath) || key.startsWith(`${deletedPath}/`) || key.startsWith(`${deletedPath}\\`)) {
-            next.delete(key)
-            changed = true
-          }
-        }
-        // 从父目录的缓存子项数组中移除已删除的条目
-        const parentPath = getDirPath(deletedPath)
-        if (parentPath && next.has(parentPath)) {
-          const parentChildren = next.get(parentPath)!
-          const filtered = parentChildren.filter(
-            (child) => !pathEquals(child.path, deletedPath)
-          )
-          if (filtered.length !== parentChildren.length) {
-            next.set(parentPath, filtered)
+      refreshSignal.affectedPaths.forEach((path) => {
+        if (!expandedFolders.has(path)) {
+          if (next.has(path)) {
+            next.delete(path)
             changed = true
           }
         }
       })
 
-      // 对于 affectedPaths，无论是否展开都先清除旧缓存
-      // 展开的目录会在下面异步重新加载
-      refreshSignal.affectedPaths.forEach((path) => {
-        if (next.has(path)) {
-          next.delete(path)
-          changed = true
+      refreshSignal.deletedPaths.forEach((deletedPath) => {
+        for (const key of next.keys()) {
+          if (pathEquals(key, deletedPath) || key.startsWith(`${deletedPath}/`) || key.startsWith(`${deletedPath}\\`)) {
+            next.delete(key)
+            changed = true
+          }
         }
       })
 

--- a/src/renderer/store/slices/fileSlice.ts
+++ b/src/renderer/store/slices/fileSlice.ts
@@ -41,11 +41,13 @@ export interface OpenFile {
   /** 文件是否已被外部删除 */
   isDeleted?: boolean
   /** 远程文件绑定信息（SFTP 编辑） */
-  remote?: { server: { host: string; port?: number; username?: string; password?: string; privateKeyPath?: string; remotePath?: string }; remotePath: string }
+  remote?: { server: { host: string; port?: number; username: string; password?: string; privateKeyPath?: string; remotePath?: string }; remotePath: string }
   /** 最后访问时间（LRU 淘汰用） */
   lastAccessed?: number
   /** Preview 文档元数据 */
   preview?: OpenPreviewMetadata
+  /** 编辑器视图状态 (Monaco saveViewState) */
+  scrollPosition?: unknown
 }
 
 export interface FileSlice {
@@ -98,6 +100,8 @@ export interface FileSlice {
   /** 标记文件已恢复（不再是删除状态） */
   markFileRestored: (path: string) => void
   updatePreviewMetadata: (path: string, preview: Partial<OpenPreviewMetadata>) => void
+  /** 设置文件滚动位置 */
+  setFileScrollPosition: (path: string, scrollPosition: { scrollTop: number; scrollLeft: number }) => void
 }
 
 function upsertOpenFiles(
@@ -326,6 +330,13 @@ export const createFileSlice: StateCreator<FileSlice, [], [], FileSlice> = (set)
         file.path === path && file.kind === 'preview' && file.preview
           ? { ...file, preview: { ...file.preview, ...preview }, lastAccessed: Date.now() }
           : file,
+      ),
+    })),
+
+  setFileScrollPosition: (path, scrollPosition) =>
+    set((state) => ({
+      openFiles: state.openFiles.map((f) =>
+        f.path === path ? { ...f, scrollPosition } : f
       ),
     })),
 })


### PR DESCRIPTION
- Add functionality to restore the editor's scroll position when a file is opened.
- Implement a mechanism to save the scroll position on scroll changes.
- Update the file slice to include scroll position in the OpenFile interface and add a method to set it.
- update refresh logic to remove unnecessary resetTree option and enhance path comparison for deleted paths