### PR TITLE
feat: 增强浮动 UI 易读性

### DIFF
--- a/src/renderer/components/dialogs/CommandPalette.tsx
+++ b/src/renderer/components/dialogs/CommandPalette.tsx
@@ -415,20 +415,19 @@ export default function CommandPalette({ onClose, onShowKeyboardShortcuts }: Com
       className="fixed inset-0 z-[9999] flex items-start justify-center pt-[15vh] animate-fade-in"
       onClick={onClose}
     >
-      <div className="fixed inset-0 bg-background/20 backdrop-blur-sm transition-opacity" />
+      <div className="overlay-scrim fixed inset-0 transition-opacity" />
 
       <div
         className="
             relative w-[640px] max-h-[60vh] flex flex-col
-            bg-background/80 backdrop-blur-2xl 
-            border border-border/50 rounded-2xl shadow-2xl shadow-black/40
+            floating-surface border rounded-2xl
             overflow-hidden animate-scale-in ring-1 ring-text-primary/5 origin-top
         "
         onClick={e => e.stopPropagation()}
       >
         {/* Search Input */}
-        <div className="flex items-center gap-4 px-6 py-5 border-b border-border/40 shrink-0">
-          <Search className="w-6 h-6 text-text-muted" strokeWidth={2} />
+        <div className="floating-surface-header flex items-center gap-4 px-6 py-5 border-b border-border/50 shrink-0">
+          <Search className="w-6 h-6 text-text-secondary" strokeWidth={2} />
           <input
             ref={inputRef}
             type="text"
@@ -436,7 +435,7 @@ export default function CommandPalette({ onClose, onShowKeyboardShortcuts }: Com
             onChange={e => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={t('typeCommandOrSearch', language)}
-            className="flex-1 bg-transparent text-xl font-medium text-text-primary placeholder:text-text-muted/40 focus:outline-none"
+            className="flex-1 bg-transparent text-xl font-medium text-text-primary placeholder:text-text-muted/55 focus:outline-none"
             spellCheck={false}
           />
           {query && (
@@ -450,10 +449,10 @@ export default function CommandPalette({ onClose, onShowKeyboardShortcuts }: Com
         </div>
 
         {/* Command List */}
-        <div ref={listRef} className="flex-1 overflow-y-auto py-3 custom-scrollbar scroll-p-2">
+        <div ref={listRef} className="relative z-[1] flex-1 overflow-y-auto py-3 custom-scrollbar scroll-p-2">
           {Object.entries(groupedCommands).map(([category, cmds]) => (
             <div key={category} className="mb-2">
-              <div className="px-6 py-1.5 text-[10px] font-bold uppercase tracking-widest text-text-muted/50 sticky top-0 bg-background/95 backdrop-blur-md z-10 mb-1">
+              <div className="floating-surface-section-label px-6 py-1.5 text-[10px] font-bold uppercase tracking-widest text-text-muted/70 sticky top-0 z-10 mb-1">
                 {category}
               </div>
               <div className="space-y-0.5 px-2">
@@ -487,17 +486,17 @@ export default function CommandPalette({ onClose, onShowKeyboardShortcuts }: Com
         </div>
 
         {/* Footer Hint */}
-        <div className="px-6 py-2.5 bg-surface/30 border-t border-border/40 text-[10px] font-medium text-text-muted/60 flex justify-between items-center backdrop-blur-md shrink-0">
+        <div className="floating-surface-footer px-6 py-2.5 border-t border-border/50 text-[10px] font-medium text-text-muted/75 flex justify-between items-center shrink-0">
           <div className="flex gap-4">
             <span className="flex items-center gap-1.5">
               <div className="flex gap-0.5">
-                <kbd className="font-sans bg-surface/80 border border-border/50 px-1 py-0.5 rounded min-w-[16px] text-center shadow-sm">↑</kbd>
-                <kbd className="font-sans bg-surface/80 border border-border/50 px-1 py-0.5 rounded min-w-[16px] text-center shadow-sm">↓</kbd>
+                <kbd className="floating-surface-chip font-sans px-1 py-0.5 rounded min-w-[16px] text-center shadow-sm">↑</kbd>
+                <kbd className="floating-surface-chip font-sans px-1 py-0.5 rounded min-w-[16px] text-center shadow-sm">↓</kbd>
               </div>
               <span>to navigate</span>
             </span>
             <span className="flex items-center gap-1.5">
-              <kbd className="font-sans bg-surface/80 border border-border/50 px-1.5 py-0.5 rounded shadow-sm">↵</kbd>
+              <kbd className="floating-surface-chip font-sans px-1.5 py-0.5 rounded shadow-sm">↵</kbd>
               <span>to select</span>
             </span>
           </div>

--- a/src/renderer/components/dialogs/QuickOpen.tsx
+++ b/src/renderer/components/dialogs/QuickOpen.tsx
@@ -297,20 +297,19 @@ export default function QuickOpen({ onClose }: QuickOpenProps) {
       className="fixed inset-0 z-[100] flex items-start justify-center pt-[15vh] animate-fade-in"
       onClick={onClose}
     >
-      <div className="fixed inset-0 bg-background/20 backdrop-blur-sm transition-opacity" />
+      <div className="overlay-scrim fixed inset-0 transition-opacity" />
 
       <div
         className="
             relative w-[640px] max-h-[65vh] flex flex-col
-            bg-background/80 backdrop-blur-2xl 
-            border border-border/50 rounded-2xl shadow-2xl shadow-black/40
+            floating-surface border rounded-2xl
             overflow-hidden animate-scale-in origin-top ring-1 ring-text-primary/5
         "
         onClick={e => e.stopPropagation()}
       >
         {/* Search Input - Big & Clean */}
-        <div className="flex items-center gap-4 px-5 py-5 border-b border-border/40 shrink-0">
-          <Search className="w-6 h-6 text-text-muted" strokeWidth={2} />
+        <div className="floating-surface-header flex items-center gap-4 px-5 py-5 border-b border-border/50 shrink-0">
+          <Search className="w-6 h-6 text-text-secondary" strokeWidth={2} />
           <input
             ref={inputRef}
             type="text"
@@ -318,7 +317,7 @@ export default function QuickOpen({ onClose }: QuickOpenProps) {
             onChange={e => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={t('searchFilesPlaceholder', language)}
-            className="flex-1 bg-transparent text-xl font-medium text-text-primary placeholder:text-text-muted/40 focus:outline-none"
+            className="flex-1 bg-transparent text-xl font-medium text-text-primary placeholder:text-text-muted/55 focus:outline-none"
             spellCheck={false}
           />
           {query && (
@@ -334,7 +333,7 @@ export default function QuickOpen({ onClose }: QuickOpenProps) {
         </div>
 
         {/* File List */}
-        <div ref={listRef} className="flex-1 overflow-y-auto py-2 custom-scrollbar scroll-p-2">
+        <div ref={listRef} className="relative z-[1] flex-1 overflow-y-auto py-2 custom-scrollbar scroll-p-2">
           {isLoading ? (
             <div className="px-4 py-16 text-center text-text-muted flex flex-col items-center gap-4">
               <div className="w-8 h-8 border-2 border-accent border-t-transparent rounded-full animate-spin" />
@@ -361,22 +360,22 @@ export default function QuickOpen({ onClose }: QuickOpenProps) {
         </div>
 
         {/* Footer */}
-        <div className="px-5 py-2.5 bg-surface/30 border-t border-border/40 text-[10px] font-medium text-text-muted/60 flex justify-between items-center shrink-0 backdrop-blur-md">
+        <div className="floating-surface-footer px-5 py-2.5 border-t border-border/50 text-[10px] font-medium text-text-muted/75 flex justify-between items-center shrink-0">
           <span className="font-mono tracking-tight">{matches.length} matches</span>
           <div className="flex items-center gap-4">
             <span className="flex items-center gap-1.5">
               <div className="flex gap-0.5">
-                <kbd className="font-sans bg-surface/80 border border-border/50 px-1 py-0.5 rounded min-w-[16px] text-center shadow-sm">↑</kbd>
-                <kbd className="font-sans bg-surface/80 border border-border/50 px-1 py-0.5 rounded min-w-[16px] text-center shadow-sm">↓</kbd>
+                <kbd className="floating-surface-chip font-sans px-1 py-0.5 rounded min-w-[16px] text-center shadow-sm">↑</kbd>
+                <kbd className="floating-surface-chip font-sans px-1 py-0.5 rounded min-w-[16px] text-center shadow-sm">↓</kbd>
               </div>
               <span>to navigate</span>
             </span>
             <span className="flex items-center gap-1.5">
-              <kbd className="font-sans bg-surface/80 border border-border/50 px-1.5 py-0.5 rounded shadow-sm">↵</kbd>
+              <kbd className="floating-surface-chip font-sans px-1.5 py-0.5 rounded shadow-sm">↵</kbd>
               <span>to open</span>
             </span>
             <span className="flex items-center gap-1.5">
-              <kbd className="font-sans bg-surface/80 border border-border/50 px-1.5 py-0.5 rounded shadow-sm">esc</kbd>
+              <kbd className="floating-surface-chip font-sans px-1.5 py-0.5 rounded shadow-sm">esc</kbd>
               <span>to close</span>
             </span>
           </div>

--- a/src/renderer/components/layout/SkinPanel.tsx
+++ b/src/renderer/components/layout/SkinPanel.tsx
@@ -103,9 +103,9 @@ export default function SkinPanel() {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 10, scale: 0.96 }}
             transition={{ type: 'spring', damping: 24, stiffness: 380 }}
-            className="absolute right-0 top-full mt-3 w-[560px] max-w-[calc(100vw-2rem)] rounded-3xl border border-border/50 bg-surface/85 backdrop-blur-3xl shadow-[0_20px_50px_rgba(0,0,0,0.28)] overflow-hidden origin-top-right"
+            className="absolute right-0 top-full mt-3 w-[560px] max-w-[calc(100vw-2rem)] rounded-3xl border border-border/70 bg-background-secondary/95 backdrop-blur-xl shadow-[0_20px_50px_rgba(0,0,0,0.28)] overflow-hidden origin-top-right"
           >
-            <div className="flex items-center justify-between px-5 py-4 border-b border-border/30">
+            <div className="flex items-center justify-between px-5 py-4 border-b border-border/40 bg-background-secondary/70">
               <div>
                 <div className="text-[10px] font-black uppercase tracking-[0.22em] text-text-muted">{copy.title}</div>
                 <div className="mt-1 text-sm text-text-secondary">{copy.subtitle}</div>
@@ -134,8 +134,8 @@ export default function SkinPanel() {
                           onClick={() => applyTheme(theme.id)}
                           className={`relative rounded-2xl border p-3 text-left transition-all ${
                             active
-                              ? 'border-accent/40 bg-accent/8 shadow-[0_0_0_1px_rgba(var(--accent),0.12)]'
-                              : 'border-border/50 bg-background/25 hover:border-accent/20 hover:bg-surface-hover/60'
+                              ? 'border-accent/40 bg-accent/10 shadow-[0_0_0_1px_rgba(var(--accent),0.12)]'
+                              : 'border-border/60 bg-background-secondary/[0.78] hover:border-accent/20 hover:bg-surface/90'
                           }`}
                         >
                           <ThemeWorkbenchPreview theme={theme} className="mb-3 h-[92px]" />
@@ -168,7 +168,7 @@ export default function SkinPanel() {
                             className={`h-10 rounded-xl border text-sm font-semibold transition-all ${
                               active
                                 ? 'border-accent/40 bg-accent/10 text-accent'
-                                : 'border-border/50 bg-background/25 text-text-secondary hover:text-text-primary hover:bg-surface-hover'
+                                : 'border-border/60 bg-background-secondary/[0.78] text-text-secondary hover:text-text-primary hover:bg-surface/90'
                             }`}
                           >
                             {Math.round(scale * 100)}%
@@ -192,8 +192,8 @@ export default function SkinPanel() {
                             onClick={() => applyLayoutDensity(item.id)}
                             className={`w-full rounded-2xl border px-4 py-3 text-left transition-all ${
                               active
-                                ? 'border-accent/40 bg-accent/8'
-                                : 'border-border/50 bg-background/25 hover:border-accent/20 hover:bg-surface-hover/60'
+                                ? 'border-accent/40 bg-accent/10'
+                                : 'border-border/60 bg-background-secondary/[0.78] hover:border-accent/20 hover:bg-surface/90'
                             }`}
                           >
                             <div className="flex items-center justify-between gap-3">

--- a/src/renderer/components/layout/UpdateIndicator.tsx
+++ b/src/renderer/components/layout/UpdateIndicator.tsx
@@ -108,9 +108,9 @@ export default function UpdateIndicator() {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 12, scale: 0.95 }}
             transition={{ type: 'spring', damping: 25, stiffness: 400 }}
-            className="absolute right-0 top-full mt-3 w-[320px] rounded-3xl bg-surface/80 backdrop-blur-3xl border border-border/50 shadow-[0_20px_50px_rgba(0,0,0,0.3)] overflow-hidden origin-top-right"
+            className="absolute right-0 top-full mt-3 w-[320px] rounded-3xl bg-background-secondary/95 backdrop-blur-xl border border-border/70 shadow-[0_20px_50px_rgba(0,0,0,0.3)] overflow-hidden origin-top-right"
           >
-            <div className="flex items-center justify-between px-6 py-4">
+            <div className="flex items-center justify-between px-6 py-4 border-b border-border/40 bg-background-secondary/70">
               <span className="text-[10px] font-black text-text-muted uppercase tracking-[0.2em]">{t.title}</span>
               <button
                 onClick={() => setShowPopover(false)}
@@ -165,7 +165,7 @@ export default function UpdateIndicator() {
                             : t.notAvailable}
                 </h4>
 
-                <div className="mt-2 flex items-center gap-2 px-3 py-1 rounded-full bg-white/5 border border-white/5 text-[11px] font-medium">
+                <div className="mt-2 flex items-center gap-2 px-3 py-1 rounded-full bg-background-secondary/[0.78] border border-border/60 text-[11px] font-medium">
                   {status?.version && hasUpdate ? (
                     <>
                       <span className="text-text-muted opacity-60">v{currentVersion}</span>

--- a/src/renderer/components/layout/WorkspaceDropdown.tsx
+++ b/src/renderer/components/layout/WorkspaceDropdown.tsx
@@ -108,7 +108,7 @@ export default function WorkspaceDropdown() {
                         animate={{ opacity: 1, y: 0, scale: 1 }}
                         exit={{ opacity: 0, y: 4, scale: 0.98 }}
                         transition={{ duration: 0.15, ease: "easeOut" }}
-                        className="absolute top-full left-0 mt-2 w-72 p-1.5 bg-background/80 backdrop-blur-xl border border-border rounded-xl shadow-2xl shadow-black/50 z-50 overflow-hidden"
+                        className="floating-surface absolute top-full left-0 mt-2 w-72 p-1.5 border border-border rounded-xl z-50 overflow-hidden"
                     >
                         <div className="space-y-0.5">
                             <MenuItem
@@ -141,7 +141,7 @@ export default function WorkspaceDropdown() {
                         {recentWorkspaces.length > 0 && (
                             <>
                                 <div className="h-px bg-border my-1.5 mx-2" />
-                                <div className="px-3 py-1.5 flex items-center gap-2">
+                                <div className="floating-surface-section-label px-3 py-1.5 flex items-center gap-2 rounded-lg mx-1">
                                     <History className="w-3 h-3 text-accent" />
                                     <span className="text-[10px] font-bold text-text-muted uppercase tracking-wider">Recent</span>
                                 </div>

--- a/src/renderer/components/ui/BottomBarPopover.tsx
+++ b/src/renderer/components/ui/BottomBarPopover.tsx
@@ -83,12 +83,12 @@ export default memo(function BottomBarPopover({
             {isOpen && (
                 <div
                     ref={popoverRef}
-                    className="absolute bottom-full right-0 mb-3 bg-surface/80 backdrop-blur-2xl border border-border/50 rounded-2xl shadow-2xl shadow-black/20 overflow-hidden animate-slide-up z-50 origin-bottom-right"
+                    className="floating-surface absolute bottom-full right-0 mb-3 border border-border/50 rounded-2xl overflow-hidden animate-slide-up z-50 origin-bottom-right"
                     style={{ width, ...(height !== undefined ? { height } : {}) }}
                 >
                     {/* 面板头部 */}
                     {title && (
-                        <div className="flex items-center justify-between px-4 py-3 border-b border-border/50 bg-white/[0.02] z-10 shrink-0">
+                        <div className="floating-surface-header flex items-center justify-between px-4 py-3 border-b border-border/50 z-10 shrink-0">
                             <span className="text-[11px] font-bold text-text-muted uppercase tracking-wider">{title}</span>
                             <button
                                 onClick={handleClose}

--- a/src/renderer/components/ui/Modal.tsx
+++ b/src/renderer/components/ui/Modal.tsx
@@ -46,7 +46,7 @@ export const Modal: React.FC<ModalProps> = memo(function Modal({
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 transition={{ duration: 0.3 }}
-                className={`absolute inset-0 ${disableGlassEffect ? 'bg-text-inverted/60' : 'bg-text-inverted/40 backdrop-blur-sm'}`}
+                className={`absolute inset-0 ${disableGlassEffect ? 'bg-text-inverted/60' : 'overlay-scrim'}`}
                 onClick={onClose}
             />
 
@@ -57,9 +57,9 @@ export const Modal: React.FC<ModalProps> = memo(function Modal({
                 transition={{ type: "spring", duration: 0.5, bounce: 0.2 }}
                 className={`
                     relative w-full ${sizeClass} 
-                    ${disableGlassEffect ? 'bg-background/95' : 'bg-background/80 backdrop-blur-2xl'}
+                    ${disableGlassEffect ? 'bg-background/95' : 'floating-surface'}
                     border border-border/50 
-                    rounded-3xl shadow-2xl shadow-black/20 
+                    rounded-3xl
                     overflow-hidden 
                     flex flex-col ${className}
                 `}
@@ -72,7 +72,7 @@ export const Modal: React.FC<ModalProps> = memo(function Modal({
                 )}
 
                 {title && (
-                    <div className="relative flex items-center justify-between px-6 py-5 border-b border-border/50 bg-text-primary/[0.02] z-10 shrink-0">
+                    <div className="floating-surface-header relative flex items-center justify-between px-6 py-5 border-b border-border/50 z-10 shrink-0">
                         <h3 className="text-lg font-bold text-text-primary tracking-tight">{title}</h3>
                         {showCloseButton && (
                             <button onClick={onClose} className="p-2 rounded-xl hover:bg-text-primary/[0.05] text-text-muted hover:text-text-primary transition-all duration-200 group">

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -80,6 +80,17 @@
   --layout-sidebar-width: 60px;
   --layout-panel-padding: 1rem;
   --layout-control-height: 2.5rem;
+  --overlay-scrim-rgb: 6 8 12;
+  --overlay-scrim-alpha: 0.34;
+  --floating-surface-alpha: 0.94;
+  --floating-surface-secondary-alpha: 0.82;
+  --floating-surface-blur: 10px;
+  --floating-surface-saturate: 112%;
+  --floating-surface-border-alpha: 0.78;
+  --floating-surface-highlight-alpha: 0.055;
+  --floating-surface-shadow:
+    0 28px 72px -30px rgba(0, 0, 0, 0.62),
+    0 18px 40px -28px rgba(0, 0, 0, 0.55);
 }
 
 /* --- Global Custom Premium Cursors --- */
@@ -100,6 +111,14 @@
   --cursor-text: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path d="M12 4h8v2h-3v20h3v2h-8v-2h3V6h-3V4z" fill="%2318181b" stroke="none"/></svg>') 16 16, text;
   --cursor-ew-resize: url('data:image/svg+xml;utf8,<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M8 12L4 16L8 20V17H24V20L28 16L24 12V15H8V12Z" fill="%2318181b" stroke="%23ffffff" stroke-width="1" stroke-linejoin="round"/></svg>') 16 16, ew-resize;
   --cursor-ns-resize: url('data:image/svg+xml;utf8,<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M12 8L16 4L20 8H17V24H20L16 28L12 24H15V8H12Z" fill="%2318181b" stroke="%23ffffff" stroke-width="1" stroke-linejoin="round"/></svg>') 16 16, ns-resize;
+  --overlay-scrim-alpha: 0.22;
+  --floating-surface-alpha: 0.965;
+  --floating-surface-secondary-alpha: 0.9;
+  --floating-surface-border-alpha: 0.88;
+  --floating-surface-highlight-alpha: 0.035;
+  --floating-surface-shadow:
+    0 26px 60px -32px rgba(15, 23, 42, 0.22),
+    0 16px 36px -28px rgba(15, 23, 42, 0.18);
 }
 
 body {
@@ -230,6 +249,83 @@ textarea,
 
 .no-drag {
   -webkit-app-region: no-drag;
+}
+
+.overlay-scrim {
+  background: rgb(var(--overlay-scrim-rgb) / var(--overlay-scrim-alpha));
+  backdrop-filter: blur(6px) saturate(108%);
+  -webkit-backdrop-filter: blur(6px) saturate(108%);
+}
+
+.floating-surface {
+  position: relative;
+  isolation: isolate;
+  background:
+    linear-gradient(
+      180deg,
+      rgb(var(--surface) / calc(var(--floating-surface-alpha) + 0.015)) 0%,
+      rgb(var(--background-secondary) / var(--floating-surface-alpha)) 100%
+    );
+  border-color: rgb(var(--border) / var(--floating-surface-border-alpha));
+  box-shadow: var(--floating-surface-shadow);
+  backdrop-filter: blur(var(--floating-surface-blur)) saturate(var(--floating-surface-saturate));
+  -webkit-backdrop-filter: blur(var(--floating-surface-blur)) saturate(var(--floating-surface-saturate));
+}
+
+.floating-surface::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background:
+    linear-gradient(
+      180deg,
+      rgb(var(--text-primary) / var(--floating-surface-highlight-alpha)) 0%,
+      transparent 24%,
+      transparent 100%
+    );
+}
+
+.floating-surface-header,
+.floating-surface-footer,
+.floating-surface-section-label {
+  position: relative;
+  z-index: 1;
+}
+
+.floating-surface-header {
+  background:
+    linear-gradient(
+      180deg,
+      rgb(var(--background-secondary) / calc(var(--floating-surface-secondary-alpha) + 0.06)) 0%,
+      rgb(var(--surface) / var(--floating-surface-secondary-alpha)) 100%
+    );
+  backdrop-filter: blur(7px) saturate(108%);
+  -webkit-backdrop-filter: blur(7px) saturate(108%);
+}
+
+.floating-surface-footer {
+  background:
+    linear-gradient(
+      180deg,
+      rgb(var(--surface) / calc(var(--floating-surface-secondary-alpha) - 0.02)) 0%,
+      rgb(var(--background-secondary) / calc(var(--floating-surface-secondary-alpha) + 0.06)) 100%
+    );
+  backdrop-filter: blur(7px) saturate(108%);
+  -webkit-backdrop-filter: blur(7px) saturate(108%);
+}
+
+.floating-surface-section-label {
+  background: rgb(var(--surface) / 0.92);
+  backdrop-filter: blur(7px) saturate(106%);
+  -webkit-backdrop-filter: blur(7px) saturate(106%);
+  box-shadow: 0 1px 0 rgb(var(--border) / 0.45);
+}
+
+.floating-surface-chip {
+  background: rgb(var(--background-secondary) / 0.76);
+  border: 1px solid rgb(var(--border) / 0.72);
 }
 
 .monaco-editor {


### PR DESCRIPTION
## 变更内容

- 为搜索、命令面板、皮肤面板、更新面板、工作区下拉、底部弹层和通用 Modal 收敛了一套共享的浮层样式。
- 提高关键浮层的背景不透明度，减轻背景内容穿透导致的文字叠加问题。
- 保留原有弹出方式和交互逻辑，尤其是皮肤面板和更新面板继续使用原来的锚点下拉展示。
- 适度保留轻量模糊、边框和阴影分层，提升可读性而不引入更重的窗口级毛玻璃方案。

## 变更范围

- `src/renderer/styles/globals.css`：新增共享浮层样式 token 和 utility。
- `QuickOpen`、`CommandPalette`：统一遮罩、头部、列表分区和底部提示的视觉层级。
- `SkinPanel`、`UpdateIndicator`：仅增强背景和边界可读性，恢复并保持原有 anchored dropdown 弹出方式。
- `Modal`、`BottomBarPopover`、`WorkspaceDropdown`：统一浮层底色、边框、阴影和轻量 blur 策略。

## 变更意义

- 这次调整的核心价值是增强浮动 UI 易读性。
- 在编辑器和聊天等高信息密度背景下，用户可以更清晰地区分输入区、标题区、列表项和辅助说明，不再因为透明度过高导致文字与背景互相打架。
- 同时保持原有交互习惯和性能开销，避免为了毛玻璃效果引入更重的原生窗口材质或高强度 blur。

## 验证

- 已执行 `npm run build`。
