### PR TITLE
feat: 打通 Shell Studio 与 Agent 的远程服务器联动

### DIFF
--- a/src/main/ipc/remoteShell.ts
+++ b/src/main/ipc/remoteShell.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import path from 'path'
 import { pipeline } from 'stream/promises'
 import type { Client as Ssh2Client, ConnectConfig, FileEntry, SFTPWrapper, Stats } from 'ssh2'
+import { remoteHostTrustService } from '../services/remoteHostTrustService'
 
 interface RemoteServerConfig {
   host: string
@@ -77,7 +78,9 @@ function isDirectoryLike(attrs: { mode?: number; isDirectory?: (() => boolean) |
 }
 
 function createConnectionConfig(server: RemoteServerConfig): ConnectConfig {
-  const config: ConnectConfig = {
+  const config: ConnectConfig & {
+    hostVerifier?: (key: Buffer, callback: (trusted: boolean) => void) => void
+  } = {
     host: server.host.trim(),
     port: server.port && server.port > 0 ? server.port : 22,
     username: server.username?.trim() || 'root',
@@ -101,6 +104,8 @@ function createConnectionConfig(server: RemoteServerConfig): ConnectConfig {
 async function withSftp<T>(server: RemoteServerConfig, handler: (sftp: SFTPWrapper) => Promise<T>): Promise<T> {
   const Client = getSsh2Client()
   const connection = new Client()
+  const trustConfig = createConnectionConfig(server)
+  let verificationError: Error | null = null
   return await new Promise<T>((resolve, reject) => {
     let settled = false
 
@@ -109,6 +114,19 @@ async function withSftp<T>(server: RemoteServerConfig, handler: (sftp: SFTPWrapp
       settled = true
       connection.end()
       reject(error)
+    }
+
+    trustConfig.hostVerifier = (key: Buffer, callback: (trusted: boolean) => void) => {
+      remoteHostTrustService.verifyOrRecordHost({
+        host: String(trustConfig.host),
+        port: Number(trustConfig.port),
+        publicKey: key,
+      }).then(() => {
+        callback(true)
+      }).catch((error) => {
+        verificationError = error instanceof Error ? error : new Error(String(error))
+        callback(false)
+      })
     }
 
     connection
@@ -133,8 +151,8 @@ async function withSftp<T>(server: RemoteServerConfig, handler: (sftp: SFTPWrapp
       .on('keyboard-interactive', (_name: string, _instructions: string, _lang: string, _prompts: Array<unknown>, finish: (responses: string[]) => void) => {
         finish([server.password || ''])
       })
-      .on('error', fail)
-      .connect(createConnectionConfig(server))
+      .on('error', (error) => fail(verificationError || error))
+      .connect(trustConfig)
   })
 }
 
@@ -266,6 +284,14 @@ async function downloadRemoteFile(sftp: SFTPWrapper, remotePath: string, localPa
 }
 
 export function registerRemoteShellHandlers(): void {
+  ipcMain.handle('remoteHostTrust:getStatus', async (_, server: RemoteServerConfig): Promise<{ known: boolean; fingerprintSha256?: string }> => {
+    return await remoteHostTrustService.getStatus(server.host, server.port)
+  })
+
+  ipcMain.handle('remoteHostTrust:getLastDecision', async (_, server: RemoteServerConfig) => {
+    return remoteHostTrustService.getLastDecision(server.host, server.port)
+  })
+
   ipcMain.handle('remoteShell:list', async (_, server: RemoteServerConfig, remotePath?: string): Promise<RemoteEntry[]> => {
     return await withSftp(server, async (sftp) => {
       const targetPath = normalizeRemotePath(remotePath || server.remotePath || '.')

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -207,6 +207,16 @@ interface RemoteShellServer {
   remotePath?: string
 }
 
+type RemoteHostTrustStatus = 'known' | 'accepted_new' | 'mismatch_rejected'
+
+interface RemoteHostTrustDecision {
+  host: string
+  port: number
+  hostTrustStatus: RemoteHostTrustStatus
+  hostFingerprintSha256: string
+  knownHostFingerprintSha256?: string
+}
+
 interface OpenFilesPayload {
   paths: string[]
   source: 'startup' | 'second-instance' | 'open-file'
@@ -314,6 +324,8 @@ export interface ElectronAPI {
   remoteShellTestConnection: (server: RemoteShellServer) => Promise<{ success: boolean; error?: string }>
   remoteShellUpload: (server: RemoteShellServer, remoteDirectory: string) => Promise<{ canceled: boolean; uploaded: string[] }>
   remoteShellDownload: (server: RemoteShellServer, remotePath: string) => Promise<{ canceled: boolean; localPath?: string }>
+  remoteHostTrustGetStatus: (server: RemoteShellServer) => Promise<{ known: boolean; fingerprintSha256?: string }>
+  remoteHostTrustGetLastDecision: (server: RemoteShellServer) => Promise<RemoteHostTrustDecision | null>
 
   // Secure Shell Execution
   executeSecureCommand: (request: {
@@ -677,6 +689,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   remoteShellTestConnection: (server: RemoteShellServer) => ipcRenderer.invoke('remoteShell:testConnection', server),
   remoteShellUpload: (server: RemoteShellServer, remoteDirectory: string) => ipcRenderer.invoke('remoteShell:upload', server, remoteDirectory),
   remoteShellDownload: (server: RemoteShellServer, remotePath: string) => ipcRenderer.invoke('remoteShell:download', server, remotePath),
+  remoteHostTrustGetStatus: (server: RemoteShellServer) => ipcRenderer.invoke('remoteHostTrust:getStatus', server),
+  remoteHostTrustGetLastDecision: (server: RemoteShellServer) => ipcRenderer.invoke('remoteHostTrust:getLastDecision', server),
 
   executeSecureCommand: (request: { command: string; args?: string[]; cwd?: string; timeout?: number; requireConfirm?: boolean }) =>
     ipcRenderer.invoke('shell:executeSecure', request),

--- a/src/main/security/secureTerminal.ts
+++ b/src/main/security/secureTerminal.ts
@@ -15,6 +15,7 @@ import { securityManager, OperationType } from './securityModule'
 import { SECURITY_DEFAULTS } from '@shared/constants'
 import { safeIpcHandle } from '../ipc/safeHandle'
 import { normalizePipeTerminalInput } from './terminalInput'
+import { remoteHostTrustService } from '../services/remoteHostTrustService'
 
 
 interface SecureShellRequest {
@@ -687,7 +688,9 @@ export function registerSecureTerminalHandlers(
       const Client = getSsh2ClientCtor()
       this.connection = new Client()
 
-      const config: Record<string, unknown> = {
+      const config: Record<string, unknown> & {
+        hostVerifier?: (key: Buffer, callback: (trusted: boolean) => void) => void
+      } = {
         host: this.server.host.trim(),
         port: this.server.port && this.server.port > 0 ? this.server.port : 22,
         username: this.server.username?.trim() || 'root',
@@ -706,10 +709,24 @@ export function registerSecureTerminalHandlers(
 
       await new Promise<void>((resolve, reject) => {
         let settled = false
+        let verificationError: Error | null = null
         const finishReject = (error: unknown) => {
           if (settled) return
           settled = true
           reject(error)
+        }
+
+        config.hostVerifier = (key: Buffer, callback: (trusted: boolean) => void) => {
+          remoteHostTrustService.verifyOrRecordHost({
+            host: String(config.host),
+            port: Number(config.port),
+            publicKey: key,
+          }).then(() => {
+            callback(true)
+          }).catch((error) => {
+            verificationError = error instanceof Error ? error : new Error(String(error))
+            callback(false)
+          })
         }
 
         this.connection
@@ -758,8 +775,9 @@ export function registerSecureTerminalHandlers(
             finish([this.server.password || ''])
           })
           .on('error', (error: unknown) => {
-            this.emit('error', error)
-            finishReject(error)
+            const effectiveError = verificationError || error
+            this.emit('error', effectiveError)
+            finishReject(effectiveError)
           })
           .on('close', () => {
             if (this.closed) return

--- a/src/main/security/secureTerminal.ts
+++ b/src/main/security/secureTerminal.ts
@@ -909,7 +909,10 @@ export function registerSecureTerminalHandlers(
       return { success: false, error: `Maximum number of terminals (${MAX_TERMINALS}) reached` }
     }
 
-    const targetCwd = (cwd && cwd.trim()) || workspace?.roots?.[0] || process.cwd()
+    const fallbackCwd = workspace?.roots?.[0] || process.cwd()
+    const targetCwd = remote?.host
+      ? fallbackCwd
+      : ((cwd && cwd.trim()) || fallbackCwd)
 
     if (workspace && workspace.roots.length > 0 && !remote?.host && !securityManager.validateWorkspacePath(targetCwd, workspace.roots)) {
       securityManager.logOperation(OperationType.TERMINAL_INTERACTIVE, 'terminal:create', false, {
@@ -965,7 +968,7 @@ export function registerSecureTerminalHandlers(
         return { success: false, error }
       }
 
-      if (!fs.existsSync(targetCwd)) {
+      if (!remote?.host && !fs.existsSync(targetCwd)) {
         const error = `Working directory not found: ${targetCwd}`
         logger.security.error(`[Terminal] ${error}`)
         return { success: false, error }

--- a/src/main/services/remoteHostTrustService.ts
+++ b/src/main/services/remoteHostTrustService.ts
@@ -1,0 +1,187 @@
+import * as crypto from 'crypto'
+import * as fs from 'fs/promises'
+import * as path from 'path'
+import { logger } from '@shared/utils/Logger'
+import { getConfigFilePath } from './configPath'
+
+export type RemoteHostTrustStatus = 'known' | 'accepted_new' | 'mismatch_rejected'
+
+export interface RemoteHostTrustRecord {
+  host: string
+  port: number
+  fingerprintSha256: string
+  addedAt: number
+  lastSeenAt: number
+}
+
+export interface RemoteHostTrustDecision {
+  host: string
+  port: number
+  hostTrustStatus: RemoteHostTrustStatus
+  hostFingerprintSha256: string
+  knownHostFingerprintSha256?: string
+}
+
+export class RemoteHostFingerprintMismatchError extends Error {
+  readonly code = 'REMOTE_HOST_FINGERPRINT_MISMATCH'
+  readonly decision: RemoteHostTrustDecision
+
+  constructor(decision: RemoteHostTrustDecision) {
+    super(
+      `Remote host fingerprint mismatch for ${decision.host}:${decision.port}. ` +
+      `Known: ${decision.knownHostFingerprintSha256 || 'unknown'}, ` +
+      `Received: ${decision.hostFingerprintSha256}.`
+    )
+    this.name = 'RemoteHostFingerprintMismatchError'
+    this.decision = decision
+  }
+}
+
+interface RemoteHostTrustStatusSnapshot {
+  known: boolean
+  fingerprintSha256?: string
+}
+
+class RemoteHostTrustService {
+  private recordsCache: RemoteHostTrustRecord[] | null = null
+  private loadPromise: Promise<RemoteHostTrustRecord[]> | null = null
+  private writeQueue: Promise<void> = Promise.resolve()
+  private lastDecisions = new Map<string, RemoteHostTrustDecision>()
+
+  getKnownHostsPath(): string {
+    return getConfigFilePath('known_hosts.json', 'ssh')
+  }
+
+  getFingerprintSha256(publicKey: Buffer): string {
+    return `SHA256:${crypto.createHash('sha256').update(publicKey).digest('base64')}`
+  }
+
+  async getStatus(host: string, port?: number): Promise<RemoteHostTrustStatusSnapshot> {
+    const record = await this.findRecord(host, port)
+    return {
+      known: Boolean(record),
+      fingerprintSha256: record?.fingerprintSha256,
+    }
+  }
+
+  getLastDecision(host: string, port?: number): RemoteHostTrustDecision | null {
+    return this.lastDecisions.get(this.getKey(host, port)) || null
+  }
+
+  async verifyOrRecordHost(input: {
+    host: string
+    port?: number
+    publicKey: Buffer
+  }): Promise<RemoteHostTrustDecision> {
+    const host = this.normalizeHost(input.host)
+    const port = this.normalizePort(input.port)
+    const hostFingerprintSha256 = this.getFingerprintSha256(input.publicKey)
+    const records = await this.loadRecords()
+    const existing = records.find(record => record.host === host && record.port === port)
+    const now = Date.now()
+
+    if (!existing) {
+      const nextRecord: RemoteHostTrustRecord = {
+        host,
+        port,
+        fingerprintSha256: hostFingerprintSha256,
+        addedAt: now,
+        lastSeenAt: now,
+      }
+      await this.persistRecords([...records, nextRecord])
+
+      const decision: RemoteHostTrustDecision = {
+        host,
+        port,
+        hostTrustStatus: 'accepted_new',
+        hostFingerprintSha256,
+      }
+      this.lastDecisions.set(this.getKey(host, port), decision)
+      return decision
+    }
+
+    if (existing.fingerprintSha256 === hostFingerprintSha256) {
+      existing.lastSeenAt = now
+      await this.persistRecords(records)
+
+      const decision: RemoteHostTrustDecision = {
+        host,
+        port,
+        hostTrustStatus: 'known',
+        hostFingerprintSha256,
+      }
+      this.lastDecisions.set(this.getKey(host, port), decision)
+      return decision
+    }
+
+    const mismatchDecision: RemoteHostTrustDecision = {
+      host,
+      port,
+      hostTrustStatus: 'mismatch_rejected',
+      hostFingerprintSha256,
+      knownHostFingerprintSha256: existing.fingerprintSha256,
+    }
+    this.lastDecisions.set(this.getKey(host, port), mismatchDecision)
+    logger.security.warn('[RemoteHostTrust] Host fingerprint mismatch', mismatchDecision)
+    throw new RemoteHostFingerprintMismatchError(mismatchDecision)
+  }
+
+  private normalizePort(port?: number): number {
+    return port && port > 0 ? port : 22
+  }
+
+  private normalizeHost(host: string): string {
+    return host.trim().toLowerCase()
+  }
+
+  private getKey(host: string, port?: number): string {
+    return `${this.normalizeHost(host)}:${this.normalizePort(port)}`
+  }
+
+  private async findRecord(host: string, port?: number): Promise<RemoteHostTrustRecord | null> {
+    const records = await this.loadRecords()
+    const normalizedHost = this.normalizeHost(host)
+    return records.find(record => record.host === normalizedHost && record.port === this.normalizePort(port)) || null
+  }
+
+  private async loadRecords(): Promise<RemoteHostTrustRecord[]> {
+    if (this.recordsCache) return this.recordsCache
+    if (this.loadPromise) return this.loadPromise
+
+    this.loadPromise = (async () => {
+      const filePath = this.getKnownHostsPath()
+      try {
+        const content = await fs.readFile(filePath, 'utf8')
+        const parsed = JSON.parse(content) as RemoteHostTrustRecord[]
+        this.recordsCache = Array.isArray(parsed) ? parsed : []
+      } catch (error) {
+        const appError = error as NodeJS.ErrnoException
+        if (appError.code !== 'ENOENT') {
+          logger.security.warn('[RemoteHostTrust] Failed to load known hosts file, using empty state', error)
+        }
+        this.recordsCache = []
+      } finally {
+        this.loadPromise = null
+      }
+
+      return this.recordsCache
+    })()
+
+    return this.loadPromise
+  }
+
+  private async persistRecords(records: RemoteHostTrustRecord[]): Promise<void> {
+    const filePath = this.getKnownHostsPath()
+    const nextRecords = records.map(record => ({ ...record }))
+
+    this.writeQueue = this.writeQueue.then(async () => {
+      await fs.mkdir(path.dirname(filePath), { recursive: true })
+      await fs.writeFile(filePath, `${JSON.stringify(nextRecords, null, 2)}\n`, 'utf8')
+      this.recordsCache = nextRecords
+    })
+
+    await this.writeQueue
+  }
+}
+
+export const remoteHostTrustService = new RemoteHostTrustService()

--- a/src/renderer/agent/core/Agent.ts
+++ b/src/renderer/agent/core/Agent.ts
@@ -152,6 +152,7 @@ export class AgentClass {
       const buildAgentSystemPrompt = await importBuildAgentSystemPrompt()
       const { prompt: systemPrompt, activeSkills } = await buildAgentSystemPrompt(chatMode, workspacePath, {
         ...promptOptions,
+        threadId,
         mentionedSkills: mentionedSkills.length > 0 ? mentionedSkills : undefined,
       })
 

--- a/src/renderer/agent/core/tools.ts
+++ b/src/renderer/agent/core/tools.ts
@@ -26,6 +26,7 @@ import { useAgentStore } from '../store/AgentStore'
 import { buildExecutionBatches } from './toolExecutionPlan'
 import { streamingEditService } from '../services/streamingEditService'
 import { resolveStreamingEditFilePath } from '../services/streamingEditPreview'
+import { shellServerRoutingService } from '../services/shellServerRoutingService'
 
 // ===== 审批服务 =====
 
@@ -168,6 +169,93 @@ function hasDependencyFailure(content: string): boolean {
   return content.startsWith('Skipped: dependency') || content.startsWith('Error: dependency')
 }
 
+const REMOTE_ROUTE_META_TOOL_NAMES = new Set([
+  'run_command',
+  'list_remote_directory',
+  'read_remote_file',
+  'write_remote_file',
+  'rename_remote_path',
+  'delete_remote_path',
+  'upload_to_remote',
+  'download_from_remote',
+])
+
+const REMOTE_ONLY_TOOL_NAMES = new Set([
+  'list_remote_directory',
+  'read_remote_file',
+  'write_remote_file',
+  'rename_remote_path',
+  'delete_remote_path',
+  'upload_to_remote',
+  'download_from_remote',
+])
+
+function buildShellRouteMeta(target: {
+  executionTarget: 'local' | 'remote'
+  resolvedBy: 'arg' | 'explicit_context' | 'last_active_server' | 'auto_routing' | 'local_default'
+  server?: { serverLinkId: string; serverName: string } | null
+}): Record<string, unknown> {
+  return {
+    executionTarget: target.executionTarget,
+    serverLinkId: target.server?.serverLinkId,
+    serverName: target.server?.serverName,
+    resolvedBy: target.resolvedBy,
+  }
+}
+
+async function enrichToolArgumentsWithRoutingMeta(
+  toolCall: ToolCall,
+  context: ToolExecutionContext
+): Promise<Record<string, unknown>> {
+  if (!REMOTE_ROUTE_META_TOOL_NAMES.has(toolCall.name)) {
+    return toolCall.arguments
+  }
+
+  const explicitServerName = typeof toolCall.arguments.server_name === 'string'
+    ? toolCall.arguments.server_name.trim()
+    : ''
+
+  if (explicitServerName) {
+    const explicitResolution = await shellServerRoutingService.resolveServerName(explicitServerName)
+    if (explicitResolution.kind === 'not_found' || explicitResolution.kind === 'ambiguous') {
+      return {
+        ...toolCall.arguments,
+        _meta: {
+          ...(toolCall.arguments._meta as Record<string, unknown> | undefined),
+          executionTarget: 'remote',
+          resolvedBy: 'arg',
+          routeError: explicitResolution.kind === 'not_found'
+            ? `Remote server not found: ${explicitServerName}`
+            : `Remote server name is ambiguous: ${explicitServerName}`,
+        },
+      }
+    }
+  }
+
+  const target = await shellServerRoutingService.resolveExecutionTarget(toolCall.name, toolCall.arguments, {
+    threadId: context.threadId,
+    assistantId: context.assistantId,
+    currentAssistantId: context.currentAssistantId,
+  })
+
+  const baseMeta = buildShellRouteMeta(target)
+  const needsRemoteButUnresolved = REMOTE_ONLY_TOOL_NAMES.has(toolCall.name) && target.executionTarget !== 'remote'
+
+  return {
+    ...toolCall.arguments,
+    _meta: {
+      ...(toolCall.arguments._meta as Record<string, unknown> | undefined),
+      ...(needsRemoteButUnresolved
+        ? {
+            executionTarget: 'remote',
+            resolvedBy: target.resolvedBy,
+            routeError: `No remote server resolved for ${toolCall.name}`,
+          }
+        : baseMeta),
+    },
+  }
+}
+
 
 /**
  * 检查工具是否需要审批
@@ -277,15 +365,17 @@ async function executeSingle(
   const { currentAssistantId, workspacePath } = context
   const identity = buildToolExecutionIdentity(toolCall, context)
   const startTime = Date.now()
+  const toolArguments = await enrichToolArgumentsWithRoutingMeta(toolCall, context)
 
   if (currentAssistantId) {
     store.finalizeTextBeforeToolCall(currentAssistantId)
     store.addToolCallPart(currentAssistantId, {
       id: toolCall.id,
       name: toolCall.name,
-      arguments: toolCall.arguments,
+      arguments: toolArguments,
     })
     store.updateToolCall(currentAssistantId, toolCall.id, {
+      arguments: toolArguments,
       status: 'running',
       streamingState: undefined,
     })
@@ -305,13 +395,13 @@ async function executeSingle(
     threadId: context.threadId ?? undefined,
     type: 'request',
     toolName: toolCall.name,
-    data: toolCall.arguments,
+    data: toolArguments,
   })
 
   try {
     const result = await toolManager.execute(
       toolCall.name,
-      toolCall.arguments,
+      toolArguments,
       {
         workspacePath: workspacePath ?? null,
         currentAssistantId: currentAssistantId ?? null,
@@ -364,8 +454,8 @@ async function executeSingle(
     // 更新状态，并将 meta 数据合并到 arguments._meta
     if (currentAssistantId) {
       const updatedArguments = Object.keys(meta).length > 0
-        ? { ...toolCall.arguments, _meta: meta }
-        : toolCall.arguments
+        ? { ...toolArguments, _meta: { ...(toolArguments._meta as Record<string, unknown> | undefined), ...meta } }
+        : toolArguments
 
       const newStatus = result.success ? 'success' : 'error'
 
@@ -622,14 +712,18 @@ export async function executeTools(
       requestId: context.requestId,
       assistantId: context.assistantId ?? context.currentAssistantId ?? undefined,
     })
+    const pendingArguments = await enrichToolArgumentsWithRoutingMeta(tc, context)
     if (context.currentAssistantId) {
-      store.updateToolCall(context.currentAssistantId, tc.id, { status: 'awaiting' })
+      store.updateToolCall(context.currentAssistantId, tc.id, {
+        arguments: pendingArguments,
+        status: 'awaiting',
+      })
     }
     emitToolEvent({
       type: 'tool:pending',
       id: tc.id,
       name: tc.name,
-      args: tc.arguments,
+      args: pendingArguments,
       ...buildToolExecutionIdentity(tc, context),
     })
 

--- a/src/renderer/agent/llm/ContextBuilder.ts
+++ b/src/renderer/agent/llm/ContextBuilder.ts
@@ -9,7 +9,7 @@ import { useStore } from '@store'
 import { useAgentStore } from '../store/AgentStore'
 import { toolRegistry } from '../tools'
 import { getAgentConfig } from '../utils/AgentConfig'
-import { ContextItem, MessageContent, TextContent, ProblemsContext, ChatMessage, getMessageText } from '../types'
+import { ContextItem, MessageContent, TextContent, ProblemsContext, ChatMessage, getMessageText, ShellServerContext } from '../types'
 import { CacheService } from '@shared/utils/CacheService'
 import { useDiagnosticsStore } from '@/renderer/services/diagnosticsStore'
 import { normalizePath } from '@shared/utils/pathUtils'
@@ -113,6 +113,9 @@ async function processContextItem(
     case 'Terminal':
       return processTerminalContext(workspacePath)
 
+    case 'ShellServer':
+      return processShellServerContext(item as ShellServerContext)
+
     case 'Symbols':
       return processSymbolsContext(workspacePath)
 
@@ -122,6 +125,12 @@ async function processContextItem(
     default:
       return null
   }
+}
+
+function processShellServerContext(item: ShellServerContext): string {
+  const login = item.username ? `${item.username}@` : ''
+  const remotePath = item.remotePath ? `\nRemote Path: ${item.remotePath}` : ''
+  return `\n### Remote Server Context\nName: ${item.serverName}\nHost: ${login}${item.host}:${item.port || 22}${remotePath}\nBinding: ${item.bindingMode}\n`
 }
 
 /**

--- a/src/renderer/agent/prompts/PromptBuilder.ts
+++ b/src/renderer/agent/prompts/PromptBuilder.ts
@@ -23,6 +23,7 @@ import {
 } from './promptTemplates'
 import { api } from '@/renderer/services/electronAPI'
 import { logger } from '@utils/Logger'
+import { shellServerRoutingService } from '../services/shellServerRoutingService'
 
 let projectSummaryCache: { path: string; summary: string; timestamp: number } | null = null
 const SUMMARY_CACHE_TTL = 5 * 60 * 1000
@@ -75,6 +76,7 @@ export interface PromptContext {
   templateId?: string
   projectSummary?: string | null
   planPhase?: 'planning' | 'executing'
+  remoteServerSection?: string | null
 }
 
 function buildTools(mode: WorkMode, templateId?: string, planPhase?: 'planning' | 'executing'): string {
@@ -129,6 +131,11 @@ ${summary.trim()}
 Note: This is an auto-generated project summary. Use it to understand the codebase structure before exploring files.`
 }
 
+function buildRemoteServerSection(section: string | null): string | null {
+  if (!section?.trim()) return null
+  return section.trim()
+}
+
 function buildSkillsSections(autoSkills: SkillItem[], mentionedSkills: SkillItem[]): (string | null)[] {
   const index = skillService.buildSkillsIndex(autoSkills) || null
   const fullContent = skillService.buildSkillsPrompt(mentionedSkills) || null
@@ -146,6 +153,7 @@ export function buildSystemPrompt(ctx: PromptContext): string {
     WORKFLOW_GUIDELINES,
     OUTPUT_FORMAT,
     buildEnvironment(ctx),
+    buildRemoteServerSection(ctx.remoteServerSection || null),
     buildProjectSummary(ctx.projectSummary || null),
     buildProjectRules(ctx.projectRules),
     buildMemory(ctx.memories),
@@ -165,6 +173,7 @@ export function buildChatPrompt(ctx: PromptContext): string {
     CODE_CONVENTIONS,
     OUTPUT_FORMAT,
     buildEnvironment(ctx),
+    buildRemoteServerSection(ctx.remoteServerSection || null),
     buildProjectSummary(ctx.projectSummary || null),
     buildProjectRules(ctx.projectRules),
     buildMemory(ctx.memories),
@@ -185,6 +194,7 @@ export async function buildAgentSystemPrompt(
     promptTemplateId?: string
     planPhase?: 'planning' | 'executing'
     mentionedSkills?: string[]
+    threadId?: string
   }
 ): Promise<{ prompt: string; activeSkills: { name: string; description: string }[] }> {
   const {
@@ -194,6 +204,7 @@ export async function buildAgentSystemPrompt(
     promptTemplateId,
     planPhase,
     mentionedSkills,
+    threadId,
   } = options || {}
 
   let template = promptTemplateId
@@ -205,11 +216,12 @@ export async function buildAgentSystemPrompt(
     template = getDefaultPromptTemplate()
   }
 
-  const [projectRules, memories, allSkills, projectSummary] = await Promise.all([
+  const [projectRules, memories, allSkills, projectSummary, remoteServerSection] = await Promise.all([
     rulesService.getRules(),
     memoryService.getMemories(),
     skillService.getSkills(),
     workspacePath ? loadProjectSummary(workspacePath) : Promise.resolve(null),
+    shellServerRoutingService.getPromptSection(threadId),
   ])
 
   const autoSkills = allSkills.filter(skill => skill.type === 'auto' && skill.enabled)
@@ -247,6 +259,7 @@ export async function buildAgentSystemPrompt(
     templateId: template.id,
     projectSummary,
     planPhase,
+    remoteServerSection,
   }
 
   const prompt = mode === 'chat' ? buildChatPrompt(ctx) : buildSystemPrompt(ctx)

--- a/src/renderer/agent/services/shellServerRoutingService.ts
+++ b/src/renderer/agent/services/shellServerRoutingService.ts
@@ -1,0 +1,408 @@
+import { Server } from 'lucide-react'
+import { useAgentStore } from '@/renderer/agent/store/AgentStore'
+import type { ChatMessage, ContextItem, LastActiveServer, ShellServerContext } from '@/renderer/agent/types'
+import { getMessageText } from '@/renderer/agent/types'
+import { shellRegistryService, type ShellLink, type RemoteServerConfig } from '@/renderer/shell'
+import type { ToolExecutionContext } from '@/shared/types'
+
+export interface RemoteShellLink extends ShellLink {
+  type: 'remote'
+  remote: RemoteServerConfig
+}
+
+export interface ShellServerMentionCandidate {
+  id: string
+  type: 'server'
+  label: string
+  description: string
+  icon: typeof Server
+  data: {
+    serverLinkId: string
+    serverName: string
+    host: string
+    port?: number
+    username?: string
+    remotePath?: string
+  }
+}
+
+export interface ResolvedShellServerTarget {
+  executionTarget: 'local' | 'remote'
+  resolvedBy: 'arg' | 'explicit_context' | 'last_active_server' | 'auto_routing' | 'local_default'
+  server?: LastActiveServer
+}
+
+export interface ExplicitShellServerResolution {
+  kind: 'none' | 'resolved' | 'not_found' | 'ambiguous'
+  token?: string
+  server?: LastActiveServer
+  matches?: LastActiveServer[]
+}
+
+const REMOTE_ONLY_TOOL_NAMES = new Set([
+  'list_remote_directory',
+  'read_remote_file',
+  'write_remote_file',
+  'rename_remote_path',
+  'delete_remote_path',
+  'upload_to_remote',
+  'download_from_remote',
+])
+
+const REMOTE_COMMAND_PATTERNS = [
+  /\b(journalctl|systemctl|service|docker|kubectl|kustomize|helm|pm2|supervisorctl|nginx|apachectl)\b/i,
+  /\b(tail|less|cat)\s+\/(var|etc|srv|opt|home)\//i,
+  /\b(ls|cd)\s+\/(var|etc|srv|opt|home)\b/i,
+  /\b(restart|deploy|reload|logs?)\b/i,
+]
+
+const LOCAL_COMMAND_PATTERNS = [
+  /\b(npm|pnpm|yarn|bun|node|vitest|jest|tsc|cargo|go\s+test|python|uv|gradle|mvn)\b/i,
+  /\bgit\s+(status|diff|log|branch|commit|checkout|switch)\b/i,
+]
+
+const REMOTE_PROMPT_PATTERNS = [
+  /远程|服务器|机器|线上|部署|日志|重启|上传|下载|ssh|shell studio|remote|server|deploy|restart|logs?/i,
+]
+
+const LOCAL_PROMPT_PATTERNS = [
+  /本地|当前项目|当前仓库|工作区|workspace|local/i,
+]
+
+function normalizeServerName(value: string): string {
+  return value.trim().toLocaleLowerCase()
+}
+
+function toLastActiveServer(link: RemoteShellLink): LastActiveServer {
+  return {
+    serverLinkId: link.id,
+    serverName: link.name.trim(),
+    host: link.remote.host.trim(),
+    port: link.remote.port,
+    username: link.remote.username,
+    remotePath: link.remote.remotePath,
+    updatedAt: Date.now(),
+  }
+}
+
+function toShellServerContext(server: LastActiveServer, bindingMode: ShellServerContext['bindingMode']): ShellServerContext {
+  return {
+    type: 'ShellServer',
+    serverLinkId: server.serverLinkId,
+    serverName: server.serverName,
+    host: server.host,
+    port: server.port,
+    username: server.username,
+    remotePath: server.remotePath,
+    bindingMode,
+  }
+}
+
+function isRemoteLink(link: ShellLink): link is RemoteShellLink {
+  return link.type === 'remote' && !!link.remote?.host
+}
+
+function contextItemsFromMessage(message: ChatMessage | undefined): ContextItem[] {
+  if (!message) return []
+  if (message.role === 'user' || message.role === 'assistant') {
+    return Array.isArray(message.contextItems) ? message.contextItems : []
+  }
+  return []
+}
+
+function findShellServerContext(items: ContextItem[]): ShellServerContext | null {
+  return items.find((item): item is ShellServerContext => item.type === 'ShellServer') || null
+}
+
+function buildServerMentionCandidate(link: RemoteShellLink): ShellServerMentionCandidate {
+  return {
+    id: `server-${link.id}`,
+    type: 'server',
+    label: `#${link.name}#`,
+    description: `${link.remote.username || 'root'}@${link.remote.host}:${link.remote.port || 22}${link.remote.remotePath ? ` · ${link.remote.remotePath}` : ''}`,
+    icon: Server,
+    data: {
+      serverLinkId: link.id,
+      serverName: link.name,
+      host: link.remote.host,
+      port: link.remote.port,
+      username: link.remote.username,
+      remotePath: link.remote.remotePath,
+    },
+  }
+}
+
+function getThreadMessages(threadId?: string | null): ChatMessage[] {
+  if (!threadId) return []
+  return useAgentStore.getState().threads[threadId]?.messages || []
+}
+
+function getLatestUserText(threadId?: string | null): string {
+  const messages = getThreadMessages(threadId)
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (message.role === 'user') {
+      return getMessageText(message.content)
+    }
+  }
+  return ''
+}
+
+function getExplicitContextServer(threadId?: string | null, assistantId?: string | null): LastActiveServer | null {
+  const messages = getThreadMessages(threadId)
+  const assistantMessage = assistantId
+    ? messages.find((message) => message.role === 'assistant' && message.id === assistantId)
+    : undefined
+  const assistantContext = findShellServerContext(contextItemsFromMessage(assistantMessage))
+  if (assistantContext) {
+    return {
+      serverLinkId: assistantContext.serverLinkId,
+      serverName: assistantContext.serverName,
+      host: assistantContext.host,
+      port: assistantContext.port,
+      username: assistantContext.username,
+      remotePath: assistantContext.remotePath,
+      updatedAt: Date.now(),
+    }
+  }
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (message.role === 'assistant') {
+      continue
+    }
+
+    if (message.role === 'user') {
+      const context = findShellServerContext(contextItemsFromMessage(message))
+      if (!context) return null
+      return {
+        serverLinkId: context.serverLinkId,
+        serverName: context.serverName,
+        host: context.host,
+        port: context.port,
+        username: context.username,
+        remotePath: context.remotePath,
+        updatedAt: Date.now(),
+      }
+    }
+  }
+
+  return null
+}
+
+function shouldTreatAsRemoteTool(toolName: string): boolean {
+  return REMOTE_ONLY_TOOL_NAMES.has(toolName)
+}
+
+function shouldTreatAsRemoteCommand(command: string, userPrompt: string): boolean {
+  if (REMOTE_COMMAND_PATTERNS.some((pattern) => pattern.test(command))) {
+    return true
+  }
+  if (LOCAL_COMMAND_PATTERNS.some((pattern) => pattern.test(command)) && !REMOTE_PROMPT_PATTERNS.some((pattern) => pattern.test(userPrompt))) {
+    return false
+  }
+  if (REMOTE_PROMPT_PATTERNS.some((pattern) => pattern.test(userPrompt))) {
+    return true
+  }
+  if (LOCAL_PROMPT_PATTERNS.some((pattern) => pattern.test(userPrompt))) {
+    return false
+  }
+  return false
+}
+
+function makeNotFoundResolution(token: string): ExplicitShellServerResolution {
+  return { kind: 'not_found', token }
+}
+
+function makeAmbiguousResolution(token: string, matches: LastActiveServer[]): ExplicitShellServerResolution {
+  return { kind: 'ambiguous', token, matches }
+}
+
+class ShellServerRoutingService {
+  private extractServerTokens(input: string): string[] {
+    const tokens: string[] = []
+    const regex = /#([^#\n]+)#/g
+    let match: RegExpExecArray | null
+    while ((match = regex.exec(input)) !== null) {
+      const token = match[1]?.trim()
+      if (token) tokens.push(token)
+    }
+    return tokens
+  }
+
+  async getRemoteServerLinks(): Promise<RemoteShellLink[]> {
+    await shellRegistryService.load()
+    return shellRegistryService.getState().links.filter(isRemoteLink)
+  }
+
+  async getRemoteServerCandidates(query: string): Promise<ShellServerMentionCandidate[]> {
+    const normalizedQuery = normalizeServerName(query.replace(/^#/, '').replace(/#$/, ''))
+    const links = await this.getRemoteServerLinks()
+    return links
+      .filter((link) => {
+        if (!normalizedQuery) return true
+        return normalizeServerName(link.name).includes(normalizedQuery)
+          || normalizeServerName(link.remote.host).includes(normalizedQuery)
+      })
+      .map(buildServerMentionCandidate)
+      .slice(0, 20)
+  }
+
+  async resolveServerName(serverName: string): Promise<ExplicitShellServerResolution> {
+    const normalized = normalizeServerName(serverName)
+    if (!normalized) return { kind: 'none' }
+
+    const links = await this.getRemoteServerLinks()
+    const matches = links
+      .filter((link) => normalizeServerName(link.name) === normalized)
+      .map(toLastActiveServer)
+
+    if (matches.length === 0) return makeNotFoundResolution(serverName)
+    if (matches.length > 1) return makeAmbiguousResolution(serverName, matches)
+    return {
+      kind: 'resolved',
+      token: serverName,
+      server: matches[0],
+    }
+  }
+
+  async resolveExplicitServerFromInput(input: string): Promise<ExplicitShellServerResolution> {
+    const tokens = this.extractServerTokens(input)
+    if (tokens.length === 0) return { kind: 'none' }
+
+    let latestResolved: ExplicitShellServerResolution = { kind: 'none' }
+    for (const token of tokens) {
+      const resolution = await this.resolveServerName(token)
+      if (resolution.kind !== 'resolved') {
+        return resolution
+      }
+      latestResolved = resolution
+    }
+
+    return latestResolved
+  }
+
+  async buildExplicitShellServerContext(input: string): Promise<{ contextItem?: ShellServerContext; lastActiveServer?: LastActiveServer; error?: string }> {
+    const resolution = await this.resolveExplicitServerFromInput(input)
+    if (resolution.kind === 'none') return {}
+    if (resolution.kind === 'not_found') {
+      return { error: `Remote server not found: #${resolution.token}#` }
+    }
+    if (resolution.kind === 'ambiguous') {
+      const labels = resolution.matches?.map((match) => match.serverName).join(', ') || resolution.token
+      return { error: `Remote server name is ambiguous: #${resolution.token}# (${labels})` }
+    }
+
+    const server = resolution.server!
+    return {
+      contextItem: toShellServerContext(server, 'explicit'),
+      lastActiveServer: server,
+    }
+  }
+
+  async getPromptSection(threadId?: string | null): Promise<string | null> {
+    const remoteLinks = await this.getRemoteServerLinks()
+    if (remoteLinks.length === 0) return null
+
+    const thread = threadId ? useAgentStore.getState().threads[threadId] : undefined
+    const lastActiveServer = thread?.lastActiveServer
+    const lines = [
+      '## Remote Server Routing',
+      '- Routing priority: tool argument `server_name` -> explicit `#server-name#` in the current user message -> recent server memory -> other conservative auto-routing evidence -> local default.',
+      '- Remote servers configured in Shell Studio can be targeted with `#server-name#` in the user message.',
+      '- `#server-name#` explicitly selects a remote server for this turn and refreshes the thread recent-server memory.',
+      '- If no explicit server is present, the recent server is only the first candidate for clearly remote tasks; it is not a hard binding.',
+      '- Local file tools operate on the local workspace only. Remote file tools operate on remote paths only.',
+      '- Never silently fall back from remote operations to local operations.',
+      '',
+      'Available remote servers:',
+      ...remoteLinks.map((link) => `- ${link.name} -> ${link.remote.username || 'root'}@${link.remote.host}:${link.remote.port || 22}${link.remote.remotePath ? ` (${link.remote.remotePath})` : ''}`),
+    ]
+
+    if (lastActiveServer) {
+      lines.push('', `Recent server candidate: ${lastActiveServer.serverName} -> ${lastActiveServer.username || 'root'}@${lastActiveServer.host}:${lastActiveServer.port || 22}${lastActiveServer.remotePath ? ` (${lastActiveServer.remotePath})` : ''}`)
+    }
+
+    return lines.join('\n')
+  }
+
+  async resolveExecutionTarget(
+    toolName: string,
+    args: Record<string, unknown>,
+    context: Pick<ToolExecutionContext, 'threadId' | 'assistantId' | 'currentAssistantId'>
+  ): Promise<ResolvedShellServerTarget> {
+    const explicitServerName = typeof args.server_name === 'string' ? args.server_name : ''
+    if (explicitServerName.trim()) {
+      const resolution = await this.resolveServerName(explicitServerName)
+      if (resolution.kind === 'resolved' && resolution.server) {
+        return {
+          executionTarget: 'remote',
+          resolvedBy: 'arg',
+          server: resolution.server,
+        }
+      }
+    }
+
+    const explicitContext = getExplicitContextServer(context.threadId, context.currentAssistantId ?? context.assistantId ?? null)
+    if (explicitContext) {
+      return {
+        executionTarget: 'remote',
+        resolvedBy: 'explicit_context',
+        server: explicitContext,
+      }
+    }
+
+    const thread = context.threadId ? useAgentStore.getState().threads[context.threadId] : undefined
+    const lastActiveServer = thread?.lastActiveServer
+    const userPrompt = getLatestUserText(context.threadId)
+
+    if (shouldTreatAsRemoteTool(toolName)) {
+      if (lastActiveServer) {
+        return {
+          executionTarget: 'remote',
+          resolvedBy: 'last_active_server',
+          server: lastActiveServer,
+        }
+      }
+
+      const remoteLinks = await this.getRemoteServerLinks()
+      if (remoteLinks.length === 1) {
+        return {
+          executionTarget: 'remote',
+          resolvedBy: 'auto_routing',
+          server: toLastActiveServer(remoteLinks[0]),
+        }
+      }
+    }
+
+    if (toolName === 'run_command') {
+      const command = typeof args.command === 'string' ? args.command : ''
+      const shouldRouteRemote = shouldTreatAsRemoteCommand(command, userPrompt)
+      if (lastActiveServer && shouldRouteRemote) {
+        return {
+          executionTarget: 'remote',
+          resolvedBy: 'last_active_server',
+          server: lastActiveServer,
+        }
+      }
+
+      if (shouldRouteRemote) {
+        const remoteLinks = await this.getRemoteServerLinks()
+        if (remoteLinks.length === 1) {
+          return {
+            executionTarget: 'remote',
+            resolvedBy: 'auto_routing',
+            server: toLastActiveServer(remoteLinks[0]),
+          }
+        }
+      }
+    }
+
+    return {
+      executionTarget: 'local',
+      resolvedBy: 'local_default',
+    }
+  }
+}
+
+export const shellServerRoutingService = new ShellServerRoutingService()

--- a/src/renderer/agent/store/AgentStore.ts
+++ b/src/renderer/agent/store/AgentStore.ts
@@ -33,6 +33,7 @@ import {
 } from './slices/planSlice'
 import { createIdleHandoffState } from '../types'
 import type { ChatMessage, ContextItem, MessageCheckpoint, StreamState, TodoItem, ContextStats, ThreadHandoffState, AssistantMessage } from '../types'
+import type { LastActiveServer } from '../types'
 import type { CompressionStats } from '../core/types'
 import type { HandoffDocument, StructuredSummary } from '../domains/context/types'
 import { buildHandoffContext } from '../domains/context/HandoffManager'
@@ -125,6 +126,8 @@ export interface ThreadBoundStore {
     getToolStreamingPreview: (toolCallId: string) => ToolStreamingPreview | undefined
     setCompressionStats: (stats: CompressionStats | null) => void
     setContextStats: (stats: ContextStats | null) => void
+    setLastActiveServer: (server: LastActiveServer | null) => void
+    clearLastActiveServer: () => void
     setExecutionMeta: (meta: import('../types').ThreadExecutionMeta | null) => void
     updateExecutionMeta: (meta: Partial<import('../types').ThreadExecutionMeta>) => void
     clearExecutionMeta: () => void
@@ -452,6 +455,8 @@ export const useAgentStore = create<AgentStore>()(
                     threadSlice.getToolStreamingPreview(toolCallId, threadId),
                 setCompressionStats: (stats) => threadSlice.setCompressionStats(stats, threadId),
                 setContextStats: (stats) => threadSlice.setContextStats(stats, threadId),
+                setLastActiveServer: (server) => threadSlice.setLastActiveServer(server, threadId),
+                clearLastActiveServer: () => threadSlice.clearLastActiveServer(threadId),
                 setExecutionMeta: (meta) => threadSlice.setExecutionMeta(meta, threadId),
                 updateExecutionMeta: (meta) => threadSlice.updateExecutionMeta(meta, threadId),
                 clearExecutionMeta: () => threadSlice.clearExecutionMeta(threadId),

--- a/src/renderer/agent/store/slices/messageSlice.ts
+++ b/src/renderer/agent/store/slices/messageSlice.ts
@@ -1292,6 +1292,9 @@ export const createMessageSlice: StateCreator<
                 if ('uri' in existing && 'uri' in item) {
                     return existing.uri === item.uri
                 }
+                if (existing.type === 'ShellServer' && item.type === 'ShellServer') {
+                    return existing.serverLinkId === item.serverLinkId
+                }
                 return existing.type === item.type
             })
 
@@ -1348,4 +1351,3 @@ export const createMessageSlice: StateCreator<
         })
     },
 })
-

--- a/src/renderer/agent/store/slices/threadSlice.ts
+++ b/src/renderer/agent/store/slices/threadSlice.ts
@@ -5,6 +5,7 @@
 
 import type { StateCreator } from 'zustand'
 import type { ChatThread, StreamState, CompressionPhase, TodoItem, ContextStats, ThreadHandoffState } from '../../types'
+import type { LastActiveServer } from '../../types'
 import type { CompressionStats } from '../../core/types'
 import type { StructuredSummary } from '../../domains/context/types'
 import type { BranchSlice } from './branchSlice'
@@ -41,6 +42,8 @@ export interface ThreadActions {
 
     setTodos: (todos: TodoItem[], threadId?: string) => void
     getTodos: (threadId?: string) => TodoItem[]
+    setLastActiveServer: (server: LastActiveServer | null, threadId?: string) => void
+    clearLastActiveServer: (threadId?: string) => void
     setExecutionMeta: (meta: import('../../types').ThreadExecutionMeta | null, threadId?: string) => void
     updateExecutionMeta: (meta: Partial<import('../../types').ThreadExecutionMeta>, threadId?: string) => void
     clearExecutionMeta: (threadId?: string) => void
@@ -458,6 +461,28 @@ export const createThreadSlice: StateCreator<
 
         const thread = get().threads[targetId]
         return thread?.todos || []
+    },
+
+    setLastActiveServer: (server, threadId) => {
+        const targetId = threadId ?? get().currentThreadId
+        if (!targetId) return
+
+        set(state => ({
+            threads: updateThread(state.threads, targetId, {
+                lastActiveServer: server || undefined,
+            }),
+        }))
+    },
+
+    clearLastActiveServer: (threadId) => {
+        const targetId = threadId ?? get().currentThreadId
+        if (!targetId) return
+
+        set(state => ({
+            threads: updateThread(state.threads, targetId, {
+                lastActiveServer: undefined,
+            }),
+        }))
     },
 
     setExecutionMeta: (meta, threadId) => {

--- a/src/renderer/agent/tools/executors.ts
+++ b/src/renderer/agent/tools/executors.ts
@@ -35,6 +35,15 @@ import type { ReplaceErrorCode } from '@/renderer/utils/smartReplace'
 import { getAgentLanguage, pickLocalizedText, translateAgentText } from '../utils/agentText'
 import { guardWriteFile } from './fileWriteStrategy'
 import { analyzeImageSource, getReadImageUnavailableMessage, getReadRichContentOptions } from '../services/imageReadService'
+import {
+    shellServerRoutingService,
+    type RemoteShellLink,
+    type ResolvedShellServerTarget,
+} from '../services/shellServerRoutingService'
+import type {
+    RemoteHostTrustDecision,
+    RemoteShellServer,
+} from '@/renderer/types/electron'
 
 // ===== 辅助函数 =====
 
@@ -418,6 +427,181 @@ function parseInlineScriptCommand(command: string): InlineScriptCommand | null {
     }
 
     return null
+}
+
+function escapeShellSingleQuotes(value: string): string {
+    return value.replace(/'/g, `'\\''`)
+}
+
+function buildShellRouteMeta(target: ResolvedShellServerTarget): Record<string, unknown> {
+    return {
+        executionTarget: target.executionTarget,
+        serverLinkId: target.server?.serverLinkId,
+        serverName: target.server?.serverName,
+        resolvedBy: target.resolvedBy,
+    }
+}
+
+function getRemotePathArg(value: unknown, fallback = '.'): string {
+    if (typeof value !== 'string') return fallback
+    const trimmed = value.trim()
+    return trimmed || fallback
+}
+
+function formatServerResolutionError(
+    toolName: string,
+    serverName: string,
+    resolution: Awaited<ReturnType<typeof shellServerRoutingService.resolveServerName>>
+): string {
+    if (resolution.kind === 'not_found') {
+        return `Remote server not found for ${toolName}: "${serverName}". Use an existing Shell Studio server name.`
+    }
+    if (resolution.kind === 'ambiguous') {
+        const labels = resolution.matches?.map(match => match.serverName).join(', ') || serverName
+        return `Remote server name is ambiguous for ${toolName}: "${serverName}" (${labels}).`
+    }
+    return `Failed to resolve remote server for ${toolName}: "${serverName}".`
+}
+
+async function resolveShellRoute(
+    toolName: string,
+    args: Record<string, unknown>,
+    ctx: Pick<ToolExecutionContext, 'threadId' | 'assistantId' | 'currentAssistantId'>,
+    options: { requireRemote: boolean }
+): Promise<
+    | { ok: true; target: ResolvedShellServerTarget; routeMeta: Record<string, unknown>; remoteLink?: RemoteShellLink }
+    | { ok: false; errorResult: ToolExecutionResult }
+> {
+    const explicitServerName = typeof args.server_name === 'string' ? args.server_name.trim() : ''
+    if (explicitServerName) {
+        const resolution = await shellServerRoutingService.resolveServerName(explicitServerName)
+        if (resolution.kind !== 'resolved' || !resolution.server) {
+            return {
+                ok: false,
+                errorResult: {
+                    success: false,
+                    result: `Error: ${formatServerResolutionError(toolName, explicitServerName, resolution)}`,
+                    error: formatServerResolutionError(toolName, explicitServerName, resolution),
+                    meta: {
+                        executionTarget: 'remote',
+                        resolvedBy: 'arg',
+                    },
+                },
+            }
+        }
+    }
+
+    const target = await shellServerRoutingService.resolveExecutionTarget(toolName, args, ctx)
+    const routeMeta = buildShellRouteMeta(target)
+
+    if (target.executionTarget !== 'remote') {
+        if (options.requireRemote) {
+            return {
+                ok: false,
+                errorResult: {
+                    success: false,
+                    result: `Error: No remote server resolved for ${toolName}. Use server_name or mention #server-name# in the user message.`,
+                    error: `No remote server resolved for ${toolName}`,
+                    meta: routeMeta,
+                },
+            }
+        }
+
+        return { ok: true, target, routeMeta }
+    }
+
+    if (!target.server) {
+        return {
+            ok: false,
+            errorResult: {
+                success: false,
+                result: `Error: Remote routing for ${toolName} did not resolve a server configuration.`,
+                error: `Remote routing for ${toolName} did not resolve a server configuration`,
+                meta: routeMeta,
+            },
+        }
+    }
+
+    const remoteLinks = await shellServerRoutingService.getRemoteServerLinks()
+    const remoteLink = remoteLinks.find(link => link.id === target.server?.serverLinkId)
+    if (!remoteLink) {
+        return {
+            ok: false,
+            errorResult: {
+                success: false,
+                result: `Error: Remote server "${target.server.serverName}" is no longer available in Shell Studio.`,
+                error: `Remote server "${target.server.serverName}" is no longer available in Shell Studio`,
+                meta: routeMeta,
+            },
+        }
+    }
+
+    return {
+        ok: true,
+        target,
+        routeMeta,
+        remoteLink,
+    }
+}
+
+function isRemoteHostMismatchError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error)
+    return message.includes('Remote host fingerprint mismatch')
+        || message.includes('REMOTE_HOST_FINGERPRINT_MISMATCH')
+}
+
+async function buildRemoteTrustMeta(
+    server: RemoteShellServer,
+    error?: unknown,
+    options?: { preferKnownStatus?: boolean }
+): Promise<Record<string, unknown>> {
+    let statusSnapshot: { known: boolean; fingerprintSha256?: string } | null = null
+    let decision: RemoteHostTrustDecision | null = null
+
+    try {
+        statusSnapshot = await api.remoteHostTrust.getStatus(server)
+    } catch {
+        statusSnapshot = null
+    }
+
+    try {
+        decision = await api.remoteHostTrust.getLastDecision(server)
+    } catch {
+        decision = null
+    }
+
+    if (decision?.hostTrustStatus === 'mismatch_rejected') {
+        if (error && !isRemoteHostMismatchError(error)) {
+            return {}
+        }
+        return {
+            hostTrustStatus: decision.hostTrustStatus,
+            hostFingerprintSha256: decision.hostFingerprintSha256,
+            knownHostFingerprintSha256: decision.knownHostFingerprintSha256,
+        }
+    }
+
+    if (decision) {
+        if (options?.preferKnownStatus && decision.hostTrustStatus === 'accepted_new' && statusSnapshot?.fingerprintSha256) {
+            return {
+                hostTrustStatus: 'known',
+                hostFingerprintSha256: statusSnapshot.fingerprintSha256,
+            }
+        }
+        return {
+            hostTrustStatus: decision.hostTrustStatus,
+            hostFingerprintSha256: decision.hostFingerprintSha256,
+        }
+    }
+
+    if (statusSnapshot?.known && statusSnapshot.fingerprintSha256) {
+        return {
+            hostTrustStatus: 'known',
+            hostFingerprintSha256: statusSnapshot.fingerprintSha256,
+        }
+    }
+
+    return {}
 }
 
 async function runInlineScriptViaTempFile(
@@ -1374,24 +1558,42 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
 
     async run_command(args, ctx) {
         const command = args.command as string
-        // cwd 解析：若 AI 传了 cwd 参数，解析为绝对路径；否则用工作区根目录
-        const resolvedCwd = args.cwd ? resolvePath(args.cwd, ctx.workspacePath, true) : null
         const isBackground = args.is_background as boolean
         const config = getAgentConfig()
         const timeout = args.timeout
             ? (args.timeout as number) * 1000
             : config.toolTimeoutMs
+        let routeMeta: Record<string, unknown> = {
+            executionTarget: 'local',
+            resolvedBy: 'local_default',
+        }
+        let remoteServerForTrust: RemoteShellServer | null = null
 
         const isLongRunningProcess = isLongRunningCommand(command, isBackground)
 
         try {
-            if (!isLongRunningProcess) {
+            const routeResolution = await resolveShellRoute('run_command', args, ctx, { requireRemote: false })
+            if (!routeResolution.ok) {
+                return routeResolution.errorResult
+            }
+
+            const { target, routeMeta: resolvedRouteMeta, remoteLink } = routeResolution
+            routeMeta = resolvedRouteMeta
+            remoteServerForTrust = remoteLink?.remote || null
+            const resolvedCwd = remoteLink
+                ? null
+                : (args.cwd ? resolvePath(args.cwd, ctx.workspacePath, true) : null)
+
+            if (!remoteLink && !isLongRunningProcess) {
                 const directExecutionResult = await runInlineScriptViaTempFile(command, ctx, timeout)
                 if (directExecutionResult) {
+                    directExecutionResult.meta = {
+                        ...(directExecutionResult.meta || {}),
+                        ...routeMeta,
+                    }
                     return directExecutionResult
                 }
             }
-
 
             // 先唤出面板，再创建/获取终端，避免竞态：
             // 若先创建终端，notify() 触发时面板还不可见 → useEffect 销毁刚创建的终端
@@ -1399,17 +1601,34 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
 
             // 获取或复用 Agent 专属终端（初始 cwd 用工作区根目录，避免反复改变终端目录）
             const terminalManager = await getTerminalManager()
-            const termId = await terminalManager.getOrCreateAgentTerminal(
-                ctx.workspacePath || '/'
+            const { terminalId: termId, reused } = await terminalManager.getOrCreateAgentTerminalLease(
+                remoteLink?.remote.remotePath || ctx.workspacePath || '/',
+                remoteLink ? {
+                    remote: remoteLink.remote,
+                    agentTerminalKey: target.server?.serverLinkId,
+                    name: `Agent · ${target.server?.serverName || remoteLink.name}`,
+                } : undefined,
             )
+            const trustMeta = remoteLink
+                ? await buildRemoteTrustMeta(remoteLink.remote, undefined, { preferKnownStatus: reused })
+                : {}
 
             // 激活 Agent 终端 tab，让用户看到执行过程
             terminalManager.setActiveTerminal(termId)
 
+            const remoteCwd = remoteLink
+                ? getRemotePathArg(args.cwd, remoteLink.remote.remotePath || '.')
+                : undefined
+            const remoteCommand = remoteLink && remoteCwd
+                ? `cd '${escapeShellSingleQuotes(remoteCwd)}' && ${command}`
+                : command
+
             // === 长进程：直接写入并立即返回，让用户在终端里跟踪 ===
             if (isLongRunningProcess) {
                 // 长进程也需要处理 cwd
-                const bgCmd = resolvedCwd
+                const bgCmd = remoteLink
+                    ? remoteCommand
+                    : resolvedCwd
                     ? (/windows/i.test(navigator.userAgent)
                         ? `Push-Location "${resolvedCwd}"; ${command}; Pop-Location`
                         : `(cd "${resolvedCwd}" && ${command})`)
@@ -1419,20 +1638,22 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
                 const detachedSession = terminalManager.recordDetachedCommand(
                     termId,
                     command,
-                    resolvedCwd || undefined,
+                    remoteLink ? remoteCwd : resolvedCwd || undefined,
                     'agent',
                 )
 
                 // 长进程占用了当前终端的 shell，释放 agentTerminalId
                 // 使下一次 run_command 自动创建新终端，避免命令被 stdin 吞掉
-                terminalManager.releaseAgentTerminal()
+                terminalManager.releaseAgentTerminal(termId)
 
                 return {
                     success: true,
                     result: `[Background Process Started]\nCommand: ${command}\nTerminal ID: ${termId}\nSession ID: ${detachedSession.commandSessionId}\n\nThe process is running in the Agent terminal panel. Use 'read_terminal_output' with terminal_id="${termId}" to check logs. Use 'send_terminal_input' to send input or Ctrl+C (is_ctrl=true). Use 'stop_terminal' to kill it.`,
                     meta: {
+                        ...routeMeta,
+                        ...trustMeta,
                         command,
-                        cwd: resolvedCwd,
+                        cwd: remoteLink ? remoteCwd : resolvedCwd,
                         terminalId: termId,
                         commandSessionId: detachedSession.commandSessionId,
                         finalStatus: detachedSession.status,
@@ -1444,9 +1665,9 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
 
             const commandResult = await terminalManager.executeCommandWithOutput(
                 termId,
-                command,
+                remoteLink ? remoteCommand : command,
                 timeout,
-                resolvedCwd || undefined,
+                remoteLink ? undefined : (resolvedCwd || undefined),
             )
 
             const displayOutput = (commandResult.output || commandResult.partialOutput || '').trim()
@@ -1480,8 +1701,10 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
                 success: commandResult.success,
                 result: resultText,
                 meta: {
+                    ...routeMeta,
+                    ...trustMeta,
                     command,
-                    cwd: resolvedCwd,
+                    cwd: remoteLink ? remoteCwd : resolvedCwd,
                     terminalId: termId,
                     commandSessionId: commandResult.commandSessionId,
                     exitCode: commandResult.exitCode,
@@ -1496,10 +1719,17 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
         } catch (error) {
             const errorMsg = error instanceof Error ? error.message : String(error)
             logger.agent.error('[run_command] Execution failed:', errorMsg)
+            const trustMeta = remoteServerForTrust
+                ? await buildRemoteTrustMeta(remoteServerForTrust, error)
+                : {}
             return {
                 success: false,
                 result: `Error: Failed to execute command: ${errorMsg}`,
-                error: errorMsg
+                error: errorMsg,
+                meta: {
+                    ...routeMeta,
+                    ...trustMeta,
+                },
             }
         }
     },
@@ -1581,6 +1811,281 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
         } catch (error) {
             const errorMsg = error instanceof Error ? error.message : String(error)
             return { success: false, result: `Failed to stop terminal: ${errorMsg}`, error: errorMsg }
+        }
+    },
+
+    async list_remote_directory(args, ctx) {
+        const routeResolution = await resolveShellRoute('list_remote_directory', args, ctx, { requireRemote: true })
+        if (!routeResolution.ok) return routeResolution.errorResult
+
+        const remotePath = getRemotePathArg(args.path, routeResolution.remoteLink?.remote.remotePath || '.')
+        const trustMetaBase = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
+
+        try {
+            const entries = await api.remoteShell.list(routeResolution.remoteLink!.remote, remotePath)
+            const trustMeta = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
+            const lines = entries.map((entry) => {
+                const kind = entry.isDirectory ? 'dir' : 'file'
+                const size = entry.isDirectory ? '' : ` (${entry.size} B)`
+                return `[${kind}] ${entry.path}${size}`
+            })
+
+            return {
+                success: true,
+                result: lines.length > 0 ? lines.join('\n') : '[Empty directory]',
+                meta: {
+                    ...routeResolution.routeMeta,
+                    ...trustMeta,
+                    path: remotePath,
+                    entryCount: entries.length,
+                },
+            }
+        } catch (error) {
+            const errorMsg = error instanceof Error ? error.message : String(error)
+            return {
+                success: false,
+                result: `Error: Failed to list remote directory: ${errorMsg}`,
+                error: errorMsg,
+                meta: {
+                    ...routeResolution.routeMeta,
+                    ...(isRemoteHostMismatchError(error)
+                        ? await buildRemoteTrustMeta(routeResolution.remoteLink!.remote, error)
+                        : trustMetaBase),
+                    path: remotePath,
+                },
+            }
+        }
+    },
+
+    async read_remote_file(args, ctx) {
+        const routeResolution = await resolveShellRoute('read_remote_file', args, ctx, { requireRemote: true })
+        if (!routeResolution.ok) return routeResolution.errorResult
+
+        const remotePath = getRemotePathArg(args.path)
+        const trustMetaBase = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
+
+        try {
+            const content = await api.remoteShell.readText(routeResolution.remoteLink!.remote, remotePath)
+            const trustMeta = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
+            return {
+                success: true,
+                result: content ?? '',
+                meta: {
+                    ...routeResolution.routeMeta,
+                    ...trustMeta,
+                    path: remotePath,
+                },
+            }
+        } catch (error) {
+            const errorMsg = error instanceof Error ? error.message : String(error)
+            return {
+                success: false,
+                result: `Error: Failed to read remote file: ${errorMsg}`,
+                error: errorMsg,
+                meta: {
+                    ...routeResolution.routeMeta,
+                    ...(isRemoteHostMismatchError(error)
+                        ? await buildRemoteTrustMeta(routeResolution.remoteLink!.remote, error)
+                        : trustMetaBase),
+                    path: remotePath,
+                },
+            }
+        }
+    },
+
+    async write_remote_file(args, ctx) {
+        const routeResolution = await resolveShellRoute('write_remote_file', args, ctx, { requireRemote: true })
+        if (!routeResolution.ok) return routeResolution.errorResult
+
+        const remotePath = getRemotePathArg(args.path)
+        const content = typeof args.content === 'string' ? args.content : ''
+        const trustMetaBase = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
+
+        try {
+            await api.remoteShell.writeText(routeResolution.remoteLink!.remote, remotePath, content)
+            const trustMeta = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
+            return {
+                success: true,
+                result: 'Remote file written successfully',
+                meta: {
+                    ...routeResolution.routeMeta,
+                    ...trustMeta,
+                    path: remotePath,
+                    contentLength: content.length,
+                },
+            }
+        } catch (error) {
+            const errorMsg = error instanceof Error ? error.message : String(error)
+            return {
+                success: false,
+                result: `Error: Failed to write remote file: ${errorMsg}`,
+                error: errorMsg,
+                meta: {
+                    ...routeResolution.routeMeta,
+                    ...(isRemoteHostMismatchError(error)
+                        ? await buildRemoteTrustMeta(routeResolution.remoteLink!.remote, error)
+                        : trustMetaBase),
+                    path: remotePath,
+                    contentLength: content.length,
+                },
+            }
+        }
+    },
+
+    async rename_remote_path(args, ctx) {
+        const routeResolution = await resolveShellRoute('rename_remote_path', args, ctx, { requireRemote: true })
+        if (!routeResolution.ok) return routeResolution.errorResult
+
+        const oldPath = getRemotePathArg(args.old_path)
+        const newPath = getRemotePathArg(args.new_path)
+        const trustMetaBase = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
+
+        try {
+            await api.remoteShell.rename(routeResolution.remoteLink!.remote, oldPath, newPath)
+            const trustMeta = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
+            return {
+                success: true,
+                result: 'Remote path renamed successfully',
+                meta: {
+                    ...routeResolution.routeMeta,
+                    ...trustMeta,
+                    oldPath,
+                    newPath,
+                },
+            }
+        } catch (error) {
+            const errorMsg = error instanceof Error ? error.message : String(error)
+            return {
+                success: false,
+                result: `Error: Failed to rename remote path: ${errorMsg}`,
+                error: errorMsg,
+                meta: {
+                    ...routeResolution.routeMeta,
+                    ...(isRemoteHostMismatchError(error)
+                        ? await buildRemoteTrustMeta(routeResolution.remoteLink!.remote, error)
+                        : trustMetaBase),
+                    oldPath,
+                    newPath,
+                },
+            }
+        }
+    },
+
+    async delete_remote_path(args, ctx) {
+        const routeResolution = await resolveShellRoute('delete_remote_path', args, ctx, { requireRemote: true })
+        if (!routeResolution.ok) return routeResolution.errorResult
+
+        const remotePath = getRemotePathArg(args.path)
+        const trustMetaBase = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
+
+        try {
+            await api.remoteShell.delete(routeResolution.remoteLink!.remote, remotePath)
+            const trustMeta = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
+            return {
+                success: true,
+                result: 'Remote path deleted successfully',
+                meta: {
+                    ...routeResolution.routeMeta,
+                    ...trustMeta,
+                    path: remotePath,
+                },
+            }
+        } catch (error) {
+            const errorMsg = error instanceof Error ? error.message : String(error)
+            return {
+                success: false,
+                result: `Error: Failed to delete remote path: ${errorMsg}`,
+                error: errorMsg,
+                meta: {
+                    ...routeResolution.routeMeta,
+                    ...(isRemoteHostMismatchError(error)
+                        ? await buildRemoteTrustMeta(routeResolution.remoteLink!.remote, error)
+                        : trustMetaBase),
+                    path: remotePath,
+                },
+            }
+        }
+    },
+
+    async upload_to_remote(args, ctx) {
+        const routeResolution = await resolveShellRoute('upload_to_remote', args, ctx, { requireRemote: true })
+        if (!routeResolution.ok) return routeResolution.errorResult
+
+        const remotePath = getRemotePathArg(args.path, routeResolution.remoteLink?.remote.remotePath || '.')
+        const trustMetaBase = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
+
+        try {
+            const uploadResult = await api.remoteShell.upload(routeResolution.remoteLink!.remote, remotePath)
+            const trustMeta = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
+            return {
+                success: true,
+                result: uploadResult.canceled
+                    ? 'Remote upload canceled by user'
+                    : uploadResult.uploaded.length > 0
+                        ? uploadResult.uploaded.join('\n')
+                        : 'No files were uploaded',
+                meta: {
+                    ...routeResolution.routeMeta,
+                    ...trustMeta,
+                    path: remotePath,
+                    canceled: uploadResult.canceled,
+                    uploaded: uploadResult.uploaded,
+                },
+            }
+        } catch (error) {
+            const errorMsg = error instanceof Error ? error.message : String(error)
+            return {
+                success: false,
+                result: `Error: Failed to upload to remote: ${errorMsg}`,
+                error: errorMsg,
+                meta: {
+                    ...routeResolution.routeMeta,
+                    ...(isRemoteHostMismatchError(error)
+                        ? await buildRemoteTrustMeta(routeResolution.remoteLink!.remote, error)
+                        : trustMetaBase),
+                    path: remotePath,
+                },
+            }
+        }
+    },
+
+    async download_from_remote(args, ctx) {
+        const routeResolution = await resolveShellRoute('download_from_remote', args, ctx, { requireRemote: true })
+        if (!routeResolution.ok) return routeResolution.errorResult
+
+        const remotePath = getRemotePathArg(args.path)
+        const trustMetaBase = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
+
+        try {
+            const downloadResult = await api.remoteShell.download(routeResolution.remoteLink!.remote, remotePath)
+            const trustMeta = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
+            return {
+                success: true,
+                result: downloadResult.canceled
+                    ? 'Remote download canceled by user'
+                    : downloadResult.localPath || 'Remote file downloaded successfully',
+                meta: {
+                    ...routeResolution.routeMeta,
+                    ...trustMeta,
+                    path: remotePath,
+                    canceled: downloadResult.canceled,
+                    localPath: downloadResult.localPath,
+                },
+            }
+        } catch (error) {
+            const errorMsg = error instanceof Error ? error.message : String(error)
+            return {
+                success: false,
+                result: `Error: Failed to download from remote: ${errorMsg}`,
+                error: errorMsg,
+                meta: {
+                    ...routeResolution.routeMeta,
+                    ...(isRemoteHostMismatchError(error)
+                        ? await buildRemoteTrustMeta(routeResolution.remoteLink!.remote, error)
+                        : trustMetaBase),
+                    path: remotePath,
+                },
+            }
         }
     },
 

--- a/src/renderer/agent/tools/executors.ts
+++ b/src/renderer/agent/tools/executors.ts
@@ -1601,8 +1601,9 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
 
             // 获取或复用 Agent 专属终端（初始 cwd 用工作区根目录，避免反复改变终端目录）
             const terminalManager = await getTerminalManager()
+            const terminalAnchorCwd = ctx.workspacePath || await api.settings.getUserDataPath()
             const { terminalId: termId, reused } = await terminalManager.getOrCreateAgentTerminalLease(
-                remoteLink?.remote.remotePath || ctx.workspacePath || '/',
+                terminalAnchorCwd,
                 remoteLink ? {
                     remote: remoteLink.remote,
                     agentTerminalKey: target.server?.serverLinkId,

--- a/src/renderer/agent/types/context.ts
+++ b/src/renderer/agent/types/context.ts
@@ -10,6 +10,7 @@ export type ContextItemType =
   | 'Codebase'
   | 'Git'
   | 'Terminal'
+  | 'ShellServer'
   | 'Symbols'
   | 'Web'
   | 'Problems'
@@ -44,6 +45,17 @@ export interface TerminalContext {
   type: 'Terminal'
 }
 
+export interface ShellServerContext {
+  type: 'ShellServer'
+  serverLinkId: string
+  serverName: string
+  host: string
+  port?: number
+  username?: string
+  remotePath?: string
+  bindingMode: 'explicit' | 'recent-memory'
+}
+
 export interface SymbolsContext {
   type: 'Symbols'
 }
@@ -75,6 +87,7 @@ export type ContextItem =
   | CodebaseContext
   | GitContext
   | TerminalContext
+  | ShellServerContext
   | SymbolsContext
   | WebContext
   | ProblemsContext

--- a/src/renderer/agent/types/thread.ts
+++ b/src/renderer/agent/types/thread.ts
@@ -64,6 +64,16 @@ export interface HandoffResumeMeta {
   createdAt: number
 }
 
+export interface LastActiveServer {
+  serverLinkId: string
+  serverName: string
+  host: string
+  port?: number
+  username?: string
+  remotePath?: string
+  updatedAt: number
+}
+
 /** Complete persisted thread record plus thread-scoped ephemeral preview state. */
 export interface ChatThread {
   id: string
@@ -100,6 +110,7 @@ export interface ChatThread {
   handoffResume?: HandoffResumeMeta
   pendingObjective?: string
   pendingSteps?: string[]
+  lastActiveServer?: LastActiveServer
 
   // ===== Thread Ownership Metadata (Phase 3.1) =====
   /** Thread mode: chat/agent/plan */
@@ -127,6 +138,7 @@ export interface PersistedChatThread {
   handoffResume?: HandoffResumeMeta
   pendingObjective?: string
   pendingSteps?: string[]
+  lastActiveServer?: LastActiveServer
   mode?: import('@/shared/types/workMode').WorkMode
   origin?: 'user' | 'plan-task'
   planId?: string
@@ -172,6 +184,7 @@ export function toPersistedChatThread(thread: ChatThread): PersistedChatThread {
     handoffResume: thread.handoffResume,
     pendingObjective: thread.pendingObjective,
     pendingSteps: thread.pendingSteps,
+    lastActiveServer: thread.lastActiveServer,
     mode: thread.mode,
     origin: thread.origin,
     planId: thread.planId,

--- a/src/renderer/agent/utils/MentionParser.ts
+++ b/src/renderer/agent/utils/MentionParser.ts
@@ -5,10 +5,11 @@
 
 import { api } from '@/renderer/services/electronAPI'
 import { logger } from '@utils/Logger'
-import { FileText, Folder, Database, Globe, FileCode, Terminal, GitBranch, AlertCircle, Wrench } from 'lucide-react'
+import { FileText, Folder, Database, Globe, FileCode, Terminal, GitBranch, AlertCircle, Wrench, Server } from 'lucide-react'
 import { skillService } from '@/renderer/agent/services/skillService'
+import { shellServerRoutingService } from '@/renderer/agent/services/shellServerRoutingService'
 
-export type MentionType = 'file' | 'folder' | 'codebase' | 'web' | 'git' | 'terminal' | 'symbols' | 'problems' | 'skill'
+export type MentionType = 'file' | 'folder' | 'codebase' | 'web' | 'git' | 'terminal' | 'symbols' | 'problems' | 'skill' | 'server'
 
 export interface MentionCandidate {
     id: string
@@ -21,7 +22,7 @@ export interface MentionCandidate {
 }
 
 export interface MentionParseResult {
-    trigger: string
+    trigger: '@' | '#'
     query: string
     range: { start: number; end: number }
 }
@@ -78,23 +79,27 @@ export class MentionParser {
     static parse(text: string, cursorPosition: number): MentionParseResult | null {
         const textBeforeCursor = text.slice(0, cursorPosition)
         const lastAt = textBeforeCursor.lastIndexOf('@')
+        const lastHash = textBeforeCursor.lastIndexOf('#')
+        const lastTriggerIndex = Math.max(lastAt, lastHash)
 
-        if (lastAt === -1) return null
+        if (lastTriggerIndex === -1) return null
+        const trigger = textBeforeCursor[lastTriggerIndex] as '@' | '#'
 
         // @ 前必须是空白或行首
-        if (lastAt > 0 && !/\s/.test(textBeforeCursor[lastAt - 1])) {
+        if (lastTriggerIndex > 0 && !/\s/.test(textBeforeCursor[lastTriggerIndex - 1])) {
             return null
         }
 
-        const query = textBeforeCursor.slice(lastAt + 1)
+        const query = textBeforeCursor.slice(lastTriggerIndex + 1)
 
         // 查询中不能有空白
         if (/[\s\n]/.test(query)) return null
+        if (trigger === '#' && query.includes('#')) return null
 
         return {
-            trigger: '@',
+            trigger,
             query,
-            range: { start: lastAt, end: cursorPosition }
+            range: { start: lastTriggerIndex, end: cursorPosition }
         }
     }
 
@@ -104,8 +109,19 @@ export class MentionParser {
     static async getSuggestions(
         query: string,
         workspacePath: string | null,
-        options: { includeFiles?: boolean; includeFolders?: boolean } = { includeFiles: true, includeFolders: true }
+        options: { includeFiles?: boolean; includeFolders?: boolean; trigger?: '@' | '#' } = { includeFiles: true, includeFolders: true, trigger: '@' }
     ): Promise<MentionCandidate[]> {
+        if (options.trigger === '#') {
+            return (await shellServerRoutingService.getRemoteServerCandidates(query)).map(candidate => ({
+                id: candidate.id,
+                type: 'server' as const,
+                label: candidate.label,
+                description: candidate.description,
+                icon: Server,
+                data: candidate.data,
+            }))
+        }
+
         const lowerQuery = query.toLowerCase()
         const suggestions: MentionCandidate[] = []
 

--- a/src/renderer/components/agent/ChatMessage.tsx
+++ b/src/renderer/components/agent/ChatMessage.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useState, useCallback, useEffect } from 'react'
-import { User, Copy, Check, Edit2, RotateCcw, ChevronDown, X, Wrench, FileText, Code, Folder, Link2 } from 'lucide-react'
+import { User, Copy, Check, Edit2, RotateCcw, ChevronDown, X, Wrench, FileText, Code, Folder, Link2, Server } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import { SyntaxHighlighter } from '@renderer/utils/syntaxHighlighter'
 import { vscDarkPlus, vs } from 'react-syntax-highlighter/dist/esm/styles/prism'
@@ -1055,6 +1055,7 @@ const ChatMessage = React.memo(({
                             case 'CodeSelection': return { bg: 'bg-purple-500/10', text: 'text-purple-400', border: 'border-transparent', Icon: Code }
                             case 'Folder': return { bg: 'bg-yellow-500/10', text: 'text-yellow-400', border: 'border-transparent', Icon: Folder }
                             case 'Skill': return { bg: 'bg-blue-500/10', text: 'text-blue-400', border: 'border-blue-500/20', Icon: Wrench }
+                            case 'ShellServer': return { bg: 'bg-emerald-500/10', text: 'text-emerald-400', border: 'border-emerald-500/20', Icon: Server }
                             default: return { bg: 'bg-text-primary/[0.04]', text: 'text-text-muted', border: 'border-transparent', Icon: FileText }
                           }
                         }
@@ -1074,6 +1075,9 @@ const ChatMessage = React.memo(({
                             }
                             case 'Skill': {
                               return `@${item.skillId || 'skill'}`
+                            }
+                            case 'ShellServer': {
+                              return `#${item.serverName || 'server'}#`
                             }
                             default: return 'Context'
                           }

--- a/src/renderer/components/agent/ChatPanel.tsx
+++ b/src/renderer/components/agent/ChatPanel.tsx
@@ -51,6 +51,7 @@ import {
 } from './chatTimelineProjection'
 import { useMessageQueueStore } from '@/renderer/agent/store/slices/queueSlice'
 import { useMessageQueueConsumer } from '@/renderer/hooks/useMessageQueue'
+import { shellServerRoutingService } from '@/renderer/agent/services/shellServerRoutingService'
 
 interface RenderableMessageItem {
   message: ChatMessageType
@@ -605,7 +606,7 @@ export default function ChatPanel() {
       const requestId = ++suggestionRequestId.current
       setMentionLoading(true)
       try {
-        const suggestions = await MentionParser.getSuggestions(parseResult.query, workspacePath)
+        const suggestions = await MentionParser.getSuggestions(parseResult.query, workspacePath, { trigger: parseResult.trigger })
         if (requestId === suggestionRequestId.current) {
           setMentionCandidates(suggestions)
         }
@@ -679,6 +680,19 @@ export default function ChatPanel() {
         replacement = '@web '
         contextItem = { type: 'Web' }
         break
+      case 'server':
+        replacement = `#${candidate.data.serverName}# `
+        contextItem = {
+          type: 'ShellServer',
+          serverLinkId: candidate.data.serverLinkId,
+          serverName: candidate.data.serverName,
+          host: candidate.data.host,
+          port: candidate.data.port,
+          username: candidate.data.username,
+          remotePath: candidate.data.remotePath,
+          bindingMode: 'explicit',
+        }
+        break
     }
 
     const newInput = textBeforeMention + replacement + textAfterMention
@@ -690,6 +704,9 @@ export default function ChatPanel() {
         if (item.type !== contextItem!.type) return false
         if (item.type === 'File' && contextItem!.type === 'File') {
           return (item as FileContext).uri === (contextItem as FileContext).uri
+        }
+        if (item.type === 'ShellServer' && contextItem!.type === 'ShellServer') {
+          return item.serverLinkId === contextItem.serverLinkId
         }
         return true
       })
@@ -707,6 +724,12 @@ export default function ChatPanel() {
   // 提交
   const handleSubmit = useCallback(async () => {
     if (!input.trim() && images.length === 0) return
+
+    const explicitServer = await shellServerRoutingService.buildExplicitShellServerContext(input)
+    if (explicitServer.error) {
+      toast.error(explicitServer.error)
+      return
+    }
 
     let userMessage: string | Array<{ type: 'text'; text: string } | { type: 'image'; source: { type: 'base64'; media_type: string; data: string } }> = input.trim()
 
@@ -745,12 +768,38 @@ export default function ChatPanel() {
     setInput('')
     setImages((prev) => { prev.forEach((img) => URL.revokeObjectURL(img.previewUrl)); return [] })
 
+    const contextItemsForSend = explicitServer.contextItem
+      ? [
+        ...contextItems.filter(item => item.type !== 'ShellServer'),
+        explicitServer.contextItem,
+      ]
+      : contextItems.filter(item => item.type !== 'ShellServer')
+
+    let targetThreadId = currentThreadId
+    if (!targetThreadId && (contextItemsForSend.length > 0 || explicitServer.lastActiveServer)) {
+      targetThreadId = createThread()
+    }
+
+    if (targetThreadId) {
+      const currentContextItems = useAgentStore.getState().threads[targetThreadId]?.contextItems || []
+      const hasDifferentContext =
+        currentContextItems.length !== contextItemsForSend.length ||
+        currentContextItems.some((item, index) => item !== contextItemsForSend[index])
+      if (hasDifferentContext) {
+        useAgentStore.getState().clearContextItems(targetThreadId)
+        contextItemsForSend.forEach((item) => useAgentStore.getState().addContextItem(item, targetThreadId))
+      }
+      if (explicitServer.lastActiveServer) {
+        useAgentStore.getState().setLastActiveServer(explicitServer.lastActiveServer, targetThreadId)
+      }
+    }
+
     // 如果正在执行中，将消息加入队列而不是直接发送
     if (isStreaming) {
       const enqueue = useMessageQueueStore.getState().enqueue
       enqueue({
         content: userMessage,
-        contextItems: [...contextItems],
+        contextItems: [...contextItemsForSend],
         chatMode,
       })
       toast.info(language === 'zh' ? '已加入发送队列' : 'Added to send queue')
@@ -761,7 +810,7 @@ export default function ChatPanel() {
     // 不依赖 followOutput 的时序，因为发送瞬间 isStreaming 还是 false
     scrollToBottom('smooth')
     await sendMessage(userMessage)
-  }, [input, images, isStreaming, sendMessage, activeFilePath, selectedCode, workspacePath, setChatMode, scrollToBottom, contextItems, chatMode, toast, language])
+  }, [input, images, isStreaming, sendMessage, activeFilePath, selectedCode, workspacePath, setChatMode, scrollToBottom, contextItems, chatMode, toast, language, currentThreadId, createThread])
 
   // 编辑消息
   const handleEditMessage = useCallback(async (messageId: string, content: string) => {

--- a/src/renderer/components/agent/ContextPanel.tsx
+++ b/src/renderer/components/agent/ContextPanel.tsx
@@ -6,6 +6,7 @@ import {
     Database,
     GitBranch,
     Terminal,
+    Server,
     X,
     Plus,
     ChevronDown,
@@ -50,6 +51,7 @@ export default function ContextPanel({
             case 'Codebase': return { icon: <Database className="w-3 h-3 text-purple-400" />, label: '@codebase' }
             case 'Git': return { icon: <GitBranch className="w-3 h-3 text-orange-400" />, label: '@git' }
             case 'Terminal': return { icon: <Terminal className="w-3 h-3 text-green-400" />, label: '@terminal' }
+            case 'ShellServer': return { icon: <Server className="w-3 h-3 text-emerald-400" />, label: `#${item.serverName}#` }
             case 'Symbols': return { icon: <Code className="w-3 h-3 text-blue-400" />, label: '@symbols' }
             default: return { icon: <File className="w-3 h-3" />, label: 'Unknown' }
         }

--- a/src/renderer/components/agent/ToolCallCard.tsx
+++ b/src/renderer/components/agent/ToolCallCard.tsx
@@ -1,5 +1,5 @@
 import { memo, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { AlertTriangle, Check, ChevronDown, Copy, FileCode, Image as ImageIcon, Search, Terminal, X } from 'lucide-react'
+import { AlertTriangle, Check, ChevronDown, Copy, FileCode, Image as ImageIcon, Search, Server, Terminal, X } from 'lucide-react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useShallow } from 'zustand/react/shallow'
 import { vscDarkPlus, vs } from 'react-syntax-highlighter/dist/esm/styles/prism'
@@ -41,6 +41,13 @@ const TOOL_LABELS: Record<string, string> = {
     create_file_or_folder: 'Create',
     delete_file_or_folder: 'Delete',
     run_command: 'Run Command',
+    list_remote_directory: 'List Remote Directory',
+    read_remote_file: 'Read Remote File',
+    write_remote_file: 'Write Remote File',
+    rename_remote_path: 'Rename Remote Path',
+    delete_remote_path: 'Delete Remote Path',
+    upload_to_remote: 'Upload To Remote',
+    download_from_remote: 'Download From Remote',
     get_lint_errors: 'Lint Errors',
     find_references: 'Find References',
     go_to_definition: 'Go to Definition',
@@ -102,6 +109,39 @@ const getPrimaryToolPath = (args: ToolArgs): string => getToolPathList(args)[0] 
 
 const getPathDisplayName = (path: string): string => getFileName(path) || path
 
+type RouteMeta = {
+    executionTarget?: 'local' | 'remote'
+    serverName?: string
+    resolvedBy?: 'arg' | 'explicit_context' | 'last_active_server' | 'auto_routing' | 'local_default'
+    routeError?: string
+    hostTrustStatus?: 'known' | 'accepted_new' | 'mismatch_rejected'
+    hostFingerprintSha256?: string
+    knownHostFingerprintSha256?: string
+}
+
+function getRouteMeta(args: ToolArgs): RouteMeta | null {
+    const meta = args._meta
+    if (!meta || typeof meta !== 'object') return null
+    return meta as RouteMeta
+}
+
+function getRouteSourceLabel(resolvedBy?: RouteMeta['resolvedBy']): string {
+    switch (resolvedBy) {
+        case 'arg':
+            return 'server_name'
+        case 'explicit_context':
+            return '#server#'
+        case 'last_active_server':
+            return 'recent memory'
+        case 'auto_routing':
+            return 'auto routing'
+        case 'local_default':
+            return 'local default'
+        default:
+            return 'routing'
+    }
+}
+
 const getPathSummary = (paths: string[], maxItems = 3): string => {
     if (paths.length === 0) return ''
     if (paths.length === 1) return getPathDisplayName(paths[0])
@@ -131,6 +171,68 @@ function getStatusText(name: string, args: ToolArgs, status: ToolCall['status'],
         return cmd
     }
 
+    if (name === 'list_remote_directory') {
+        const remotePath = asString(args.path) || '.'
+        if (isRunning) return `Listing remote ${remotePath}...`
+        if (isSuccess) return `Listed remote ${remotePath}`
+        if (isError) return `Failed to list remote ${remotePath}`
+        return `Listing remote ${remotePath}`
+    }
+
+    if (name === 'read_remote_file') {
+        const remotePath = asString(args.path)
+        if (!remotePath) return isRunning ? 'Reading remote file...' : ''
+        if (isRunning) return `Reading remote ${remotePath}...`
+        if (isSuccess) return `Read remote ${remotePath}`
+        if (isError) return `Failed to read remote ${remotePath}`
+        return `Reading remote ${remotePath}`
+    }
+
+    if (name === 'write_remote_file') {
+        const remotePath = asString(args.path)
+        if (!remotePath) return isRunning ? 'Writing remote file...' : ''
+        if (isRunning) return `Writing remote ${remotePath}...`
+        if (isSuccess) return `Wrote remote ${remotePath}`
+        if (isError) return `Failed to write remote ${remotePath}`
+        return `Writing remote ${remotePath}`
+    }
+
+    if (name === 'rename_remote_path') {
+        const oldPath = asString(args.old_path)
+        const newPath = asString(args.new_path)
+        const summary = oldPath && newPath ? `${oldPath} -> ${newPath}` : 'remote path'
+        if (isRunning) return `Renaming ${summary}...`
+        if (isSuccess) return `Renamed ${summary}`
+        if (isError) return `Failed to rename ${summary}`
+        return `Renaming ${summary}`
+    }
+
+    if (name === 'delete_remote_path') {
+        const remotePath = asString(args.path)
+        if (!remotePath) return isRunning ? 'Deleting remote path...' : ''
+        if (isRunning) return `Deleting remote ${remotePath}...`
+        if (isSuccess) return `Deleted remote ${remotePath}`
+        if (isError) return `Failed to delete remote ${remotePath}`
+        return `Deleting remote ${remotePath}`
+    }
+
+    if (name === 'upload_to_remote') {
+        const remotePath = asString(args.path) || '.'
+        if (isRunning) return `Uploading to remote ${remotePath}...`
+        if (isSuccess) return `Uploaded to remote ${remotePath}`
+        if (isError) return `Failed to upload to remote ${remotePath}`
+        return `Uploading to remote ${remotePath}`
+    }
+
+    if (name === 'download_from_remote') {
+        const remotePath = asString(args.path)
+        if (!remotePath) return isRunning ? 'Downloading remote file...' : ''
+        if (isRunning) return `Downloading remote ${remotePath}...`
+        if (isSuccess) return `Downloaded remote ${remotePath}`
+        if (isError) return `Failed to download remote ${remotePath}`
+        return `Downloading remote ${remotePath}`
+    }
+
     if (name === 'read_multiple_files') {
         if (paths.length > 0) {
             if (isRunning) return `Reading ${pathSummary}...`
@@ -149,7 +251,7 @@ function getStatusText(name: string, args: ToolArgs, status: ToolCall['status'],
         return `Analyzing ${path}`
     }
 
-    if (['read_file', 'list_directory'].includes(name)) {
+    if (['read_file', 'list_directory', 'read_remote_file', 'list_remote_directory'].includes(name)) {
         if (paths.length > 1) {
             if (isRunning) return `Reading ${pathSummary}...`
             if (isSuccess) return `Read ${pathSummary}`
@@ -256,6 +358,56 @@ function PendingPreviewSkeleton() {
         <div className="p-2 space-y-1.5 opacity-70" aria-hidden="true">
             <div className="h-2 rounded-full bg-text-primary/[0.06] animate-pulse w-[72%]" />
             <div className="h-2 rounded-full bg-text-primary/[0.06] animate-pulse w-[48%]" />
+        </div>
+    )
+}
+
+function ExecutionTargetBadge({ args }: { args: ToolArgs }) {
+    const routeMeta = getRouteMeta(args)
+    if (!routeMeta?.executionTarget) return null
+
+    const isRemote = routeMeta.executionTarget === 'remote'
+
+    return (
+        <div className="space-y-1">
+            <div className="flex flex-wrap items-center gap-1.5 text-[10px]">
+                <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 border ${
+                    isRemote
+                        ? 'bg-sky-500/10 text-sky-300 border-sky-500/20'
+                        : 'bg-surface-elevated text-text-muted border-border/60'
+                }`}>
+                    {isRemote ? <Server className="w-3 h-3" /> : <Terminal className="w-3 h-3" />}
+                    {isRemote ? 'Remote' : 'Local'}
+                </span>
+                {routeMeta.serverName && (
+                    <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 bg-surface-elevated text-text-secondary border border-border/60">
+                        {routeMeta.serverName}
+                    </span>
+                )}
+                {routeMeta.resolvedBy && (
+                    <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 bg-surface-elevated text-text-muted border border-border/60">
+                        via {getRouteSourceLabel(routeMeta.resolvedBy)}
+                    </span>
+                )}
+            </div>
+            {routeMeta.routeError && (
+                <div className="text-[10px] text-amber-400 break-all">
+                    {routeMeta.routeError}
+                </div>
+            )}
+            {isRemote && routeMeta.hostTrustStatus === 'accepted_new' && (
+                <div className="text-[10px] text-emerald-300 break-all">
+                    Trusted this host fingerprint automatically for future remote sessions.
+                    {routeMeta.hostFingerprintSha256 ? ` ${routeMeta.hostFingerprintSha256}` : ''}
+                </div>
+            )}
+            {isRemote && routeMeta.hostTrustStatus === 'mismatch_rejected' && (
+                <div className="text-[10px] text-red-300 break-all">
+                    Host fingerprint mismatch blocked the remote connection.
+                    {routeMeta.knownHostFingerprintSha256 ? ` Known: ${routeMeta.knownHostFingerprintSha256}.` : ''}
+                    {routeMeta.hostFingerprintSha256 ? ` Received: ${routeMeta.hostFingerprintSha256}.` : ''}
+                </div>
+            )}
         </div>
     )
 }
@@ -516,9 +668,9 @@ function ToolPreview({
         )
     }
 
-    if (effectiveName === 'list_directory') {
+    if (['list_directory', 'list_remote_directory'].includes(effectiveName)) {
         const paths = getToolPathList(args)
-        const path = paths[0] || ''
+        const path = paths[0] || asString(args.path) || ''
         const displayName = paths.length > 1 ? getPathSummary(paths) : getPathDisplayName(path) || '.'
 
         return (
@@ -535,7 +687,7 @@ function ToolPreview({
                         </div>
                     </ExpandablePreviewContainer>
                 ) : (isRunning || isStreaming) && (
-                    pendingPreview('Reading directory...')
+                    pendingPreview(effectiveName === 'list_remote_directory' ? 'Reading remote directory...' : 'Reading directory...')
                 )}
             </div>
         )
@@ -643,9 +795,9 @@ function ToolPreview({
         )
     }
 
-    if (['read_file', 'read_multiple_files'].includes(effectiveName)) {
+    if (['read_file', 'read_multiple_files', 'read_remote_file'].includes(effectiveName)) {
         const paths = getToolPathList(args)
-        const filePath = paths[0] || ''
+        const filePath = paths[0] || asString(args.path) || ''
         const readMeta = args._meta && typeof args._meta === 'object' ? args._meta as Record<string, unknown> : undefined
         const contentKind = typeof readMeta?.contentKind === 'string' ? readMeta.contentKind : undefined
         const isDocumentRead = contentKind === 'document'
@@ -687,7 +839,7 @@ function ToolPreview({
                         )}
                     </ExpandablePreviewContainer>
                 ) : (isRunning || isStreaming) && (
-                    pendingPreview('Reading file...')
+                    pendingPreview(effectiveName === 'read_remote_file' ? 'Reading remote file...' : 'Reading file...')
                 )}
             </div>
         )
@@ -884,6 +1036,7 @@ const ToolCallCard = memo(function ToolCallCard({
                     }}
                     setTerminalVisible={setTerminalVisible}
                 />
+                <ExecutionTargetBadge args={args} />
                 {toolCall.error && (
                     <div className="px-3 py-2 bg-red-500/10 rounded-md">
                         <div className="flex items-center gap-2 text-red-400 text-xs font-medium mb-1">

--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -15,6 +15,7 @@ import {
   Folder,
   Globe,
   Wrench,
+  Server,
   Image as ImageIcon,
   ListOrdered
 } from 'lucide-react'
@@ -199,13 +200,14 @@ const ChatInput = memo(function ChatInput({
               )}
 
               {/* Context Items */}
-              {contextItems.filter(item => ['File', 'Folder', 'CodeSelection', 'Skill'].includes(item.type)).map((item, i) => {
+              {contextItems.filter(item => ['File', 'Folder', 'CodeSelection', 'Skill', 'ShellServer'].includes(item.type)).map((item, i) => {
                 const getContextStyle = (type: string) => {
                   switch (type) {
                     case 'File': return { bg: 'bg-text-primary/[0.04]', text: 'text-text-secondary', border: 'border-transparent', Icon: FileText }
                     case 'CodeSelection': return { bg: 'bg-purple-500/10', text: 'text-purple-400', border: 'border-transparent', Icon: Code }
                     case 'Folder': return { bg: 'bg-yellow-500/10', text: 'text-yellow-400', border: 'border-transparent', Icon: Folder }
                     case 'Skill': return { bg: 'bg-blue-500/10', text: 'text-blue-400', border: 'border-blue-500/20', Icon: Wrench }
+                    case 'ShellServer': return { bg: 'bg-emerald-500/10', text: 'text-emerald-400', border: 'border-emerald-500/20', Icon: Server }
                     default: return { bg: 'bg-text-primary/[0.04]', text: 'text-text-muted', border: 'border-transparent', Icon: FileText }
                   }
                 }
@@ -227,6 +229,9 @@ const ChatInput = memo(function ChatInput({
                     }
                     case 'Skill': {
                       return `@${(item as import('@/renderer/agent/types').SkillContext).skillId || 'skill'}`
+                    }
+                    case 'ShellServer': {
+                      return `#${(item as import('@/renderer/agent/types').ShellServerContext).serverName}#`
                     }
                     default: return 'Context'
                   }

--- a/src/renderer/services/TerminalManager.ts
+++ b/src/renderer/services/TerminalManager.ts
@@ -113,6 +113,11 @@ export interface CommandResult {
   signal?: number;
 }
 
+export interface AgentTerminalLease {
+  terminalId: string;
+  reused: boolean;
+}
+
 export interface TerminalDataEvent {
   id: string;
   data: string;
@@ -269,6 +274,8 @@ class TerminalManagerClass {
   /** Agent 专属终端 ID（跨 tool call 复用） */
   private agentTerminalId: string | null = null;
   private agentTerminalCreating: Promise<string> | null = null;
+  private agentRemoteTerminalIds = new Map<string, string>();
+  private agentRemoteTerminalCreating = new Map<string, Promise<string>>();
 
   // xterm 实例管理
   private xtermInstances = new Map<string, XTermInstance>();
@@ -283,6 +290,7 @@ class TerminalManagerClass {
   // PTY 状态
   private ptyReady = new Map<string, boolean>();
   private pendingPtyCreation = new Map<string, Promise<boolean>>();
+  private terminalCreateErrors = new Map<string, string>();
 
   // 监听器
   private stateListeners = new Set<StateListener>();
@@ -578,8 +586,14 @@ class TerminalManagerClass {
     try {
       const success = await ptyPromise;
       this.ptyReady.set(id, success);
+      if (!success && !this.terminalCreateErrors.has(id)) {
+        this.terminalCreateErrors.set(id, 'Failed to create terminal session')
+      }
     } catch {
       this.ptyReady.set(id, false);
+      if (!this.terminalCreateErrors.has(id)) {
+        this.terminalCreateErrors.set(id, 'Failed to create terminal session')
+      }
     } finally {
       this.pendingPtyCreation.delete(id);
     }
@@ -598,6 +612,7 @@ class TerminalManagerClass {
       const result = await api.terminal.create({ id, cwd, shell, backend, remote });
       if (!result?.success) {
         const errorMsg = result?.error || "Unknown error";
+        this.terminalCreateErrors.set(id, errorMsg)
         logger.system.error(
           `[TerminalManager] Failed to create PTY for ${id}:`,
           errorMsg,
@@ -618,6 +633,7 @@ class TerminalManagerClass {
       return true;
     } catch (err) {
       const error = toAppError(err);
+      this.terminalCreateErrors.set(id, error.message)
       logger.system.error(
         `[TerminalManager] Exception creating PTY for ${id}: ${error.code}`,
         error,
@@ -826,12 +842,11 @@ class TerminalManagerClass {
       this.xtermInstances.delete(id);
     }
 
-    if (this.agentTerminalId === id) {
-      this.agentTerminalId = null
-    }
+    this.removeAgentTerminalReference(id)
 
     this.outputBuffers.delete(id);
     this.ptyReady.delete(id);
+    this.terminalCreateErrors.delete(id);
     this.clearCommandState(id)
     api.terminal.kill(id);
 
@@ -905,6 +920,14 @@ class TerminalManagerClass {
     return this.xtermInstances.get(id)?.terminal || null;
   }
 
+  getTerminalCreateError(id: string): string | null {
+    return this.terminalCreateErrors.get(id) || null
+  }
+
+  isTerminalReady(id: string): boolean {
+    return this.ptyReady.get(id) === true
+  }
+
   focusTerminal(id: string) {
     const xterm = this.xtermInstances.get(id);
     if (xterm) {
@@ -914,46 +937,117 @@ class TerminalManagerClass {
 
   // ===== Agent 专属终端 =====
 
+  private isReusableAgentTerminal(terminalId: string): boolean {
+    const exists = this.state.terminals.find(t => t.id === terminalId)
+    if (!exists) return false
+
+    const commandInfo = this.getTerminalCommandState(terminalId)
+    const occupiedByDetachedWork =
+      commandInfo.current?.status === 'detached' ||
+      commandInfo.last?.status === 'detached'
+    const occupiedByActiveCommand =
+      commandInfo.current?.status === 'queued' ||
+      commandInfo.current?.status === 'running'
+
+    return !occupiedByDetachedWork && !occupiedByActiveCommand
+  }
+
+  private removeAgentTerminalReference(id: string): void {
+    if (this.agentTerminalId === id) {
+      this.agentTerminalId = null
+    }
+
+    for (const [key, value] of this.agentRemoteTerminalIds.entries()) {
+      if (value === id) {
+        this.agentRemoteTerminalIds.delete(key)
+      }
+    }
+  }
+
   /**
    * 获取或创建 Agent 专属终端。
    * Agent 终端跨 tool call 复用，避免每次 run_command 产生孤立 tab。
    */
-  async getOrCreateAgentTerminal(cwd: string, shell?: string): Promise<string> {
+  async getOrCreateAgentTerminalLease(cwd: string, options?: {
+    shell?: string
+    remote?: TerminalInstance['remote']
+    agentTerminalKey?: string
+    name?: string
+  }): Promise<AgentTerminalLease> {
+    if (options?.remote) {
+      const key = options.agentTerminalKey || `${options.remote.username || 'root'}@${options.remote.host}:${options.remote.port || 22}`
+      const existingId = this.agentRemoteTerminalIds.get(key)
+      if (existingId) {
+        if (this.isReusableAgentTerminal(existingId)) {
+          return { terminalId: existingId, reused: true }
+        }
+        this.agentRemoteTerminalIds.delete(key)
+      }
+
+      const pendingCreation = this.agentRemoteTerminalCreating.get(key)
+      if (pendingCreation) {
+        const terminalId = await pendingCreation
+        return { terminalId, reused: false }
+      }
+
+      const creating = this.createTerminal({
+        name: options.name || 'Agent',
+        cwd,
+        shell: options.shell,
+        isAgent: true,
+        remote: options.remote,
+      }).then(id => {
+        if (!this.isTerminalReady(id)) {
+          const error = this.getTerminalCreateError(id) || 'Failed to create remote terminal session'
+          this.removeAgentTerminalReference(id)
+          if (this.hasTerminal(id)) {
+            this.closeTerminal(id)
+          }
+          throw new Error(error)
+        }
+        this.agentRemoteTerminalIds.set(key, id)
+        this.cleanupIdleAgentTerminals()
+        this.agentRemoteTerminalCreating.delete(key)
+        return id
+      }).catch(err => {
+        this.agentRemoteTerminalCreating.delete(key)
+        throw err
+      })
+
+      this.agentRemoteTerminalCreating.set(key, creating)
+      const terminalId = await creating
+      return { terminalId, reused: false }
+    }
+
     // 检查现有 agent 终端是否仍然存活
     if (this.agentTerminalId) {
-      const exists = this.state.terminals.find(t => t.id === this.agentTerminalId)
-      if (exists) {
-        const commandInfo = this.getTerminalCommandState(this.agentTerminalId)
-        const occupiedByDetachedWork =
-          commandInfo.current?.status === 'detached' ||
-          commandInfo.last?.status === 'detached'
-        const occupiedByActiveCommand =
-          commandInfo.current?.status === 'queued' ||
-          commandInfo.current?.status === 'running'
-
-        if (!occupiedByDetachedWork && !occupiedByActiveCommand) {
-          return this.agentTerminalId
-        }
-
-        this.agentTerminalId = null
-      }
-      // 已被关闭，重置
-      else {
+      if (this.isReusableAgentTerminal(this.agentTerminalId)) {
+        return { terminalId: this.agentTerminalId, reused: true }
+      } else {
         this.agentTerminalId = null
       }
     }
 
     // 并发锁：防止快速连续的 run_command 创建多个 Agent 终端
     if (this.agentTerminalCreating) {
-      return this.agentTerminalCreating
+      const terminalId = await this.agentTerminalCreating
+      return { terminalId, reused: false }
     }
 
     this.agentTerminalCreating = this.createTerminal({
-      name: this.getNextAgentTerminalName(),
+      name: options?.name || this.getNextAgentTerminalName(),
       cwd,
-      shell,
+      shell: options?.shell,
       isAgent: true,
     }).then(id => {
+      if (!this.isTerminalReady(id)) {
+        const error = this.getTerminalCreateError(id) || 'Failed to create terminal session'
+        this.removeAgentTerminalReference(id)
+        if (this.hasTerminal(id)) {
+          this.closeTerminal(id)
+        }
+        throw new Error(error)
+      }
       this.agentTerminalId = id
       this.cleanupIdleAgentTerminals()
       this.agentTerminalCreating = null
@@ -963,15 +1057,31 @@ class TerminalManagerClass {
       throw err
     })
 
-    return this.agentTerminalCreating
+    const terminalId = await this.agentTerminalCreating
+    return { terminalId, reused: false }
+  }
+
+  async getOrCreateAgentTerminal(cwd: string, options?: {
+    shell?: string
+    remote?: TerminalInstance['remote']
+    agentTerminalKey?: string
+    name?: string
+  }): Promise<string> {
+    const lease = await this.getOrCreateAgentTerminalLease(cwd, options)
+    return lease.terminalId
   }
 
   /**
    * 释放当前 Agent 终端绑定（不关闭终端）。
    * 长进程占用终端后调用，使下一次 getOrCreateAgentTerminal() 创建新终端。
    */
-  releaseAgentTerminal() {
-    this.agentTerminalId = null
+  releaseAgentTerminal(terminalId?: string) {
+    if (!terminalId) {
+      this.agentTerminalId = null
+      return
+    }
+
+    this.removeAgentTerminalReference(terminalId)
   }
 
   private getNextAgentTerminalName(): string {
@@ -981,9 +1091,14 @@ class TerminalManagerClass {
   }
 
   private cleanupIdleAgentTerminals(): void {
+    const reservedAgentTerminalIds = new Set<string>([
+      this.agentTerminalId,
+      ...this.agentRemoteTerminalIds.values(),
+    ].filter((id): id is string => Boolean(id)))
+
     const idleAgentTerminals = this.state.terminals
       .filter(terminal => terminal.isAgent)
-      .filter(terminal => terminal.id !== this.agentTerminalId)
+      .filter(terminal => !reservedAgentTerminalIds.has(terminal.id))
       .filter(terminal => terminal.id !== this.state.activeId)
       .filter((terminal) => {
         const commandInfo = this.getTerminalCommandState(terminal.id)
@@ -1324,6 +1439,8 @@ class TerminalManagerClass {
 
     this.agentTerminalId = null
     this.agentTerminalCreating = null
+    this.agentRemoteTerminalIds.clear()
+    this.agentRemoteTerminalCreating.clear()
     this.currentCommandSessions.clear()
     this.lastCommandSessions.clear()
     this.activeExecutions.clear()

--- a/src/renderer/services/electronAPI.ts
+++ b/src/renderer/services/electronAPI.ts
@@ -9,6 +9,7 @@ import type {
   RemoteShellServer,
   RemoteShellUploadResult,
   RemoteShellDownloadResult,
+  RemoteHostTrustDecision,
 } from '@renderer/types/electron'
 
 type ElectronAPIWithRemoteShell = ElectronAPI & {
@@ -21,6 +22,8 @@ type ElectronAPIWithRemoteShell = ElectronAPI & {
   remoteShellTestConnection: (server: RemoteShellServer) => Promise<{ success: boolean; error?: string }>
   remoteShellUpload: (server: RemoteShellServer, remoteDirectory: string) => Promise<RemoteShellUploadResult>
   remoteShellDownload: (server: RemoteShellServer, remotePath: string) => Promise<RemoteShellDownloadResult>
+  remoteHostTrustGetStatus: (server: RemoteShellServer) => Promise<{ known: boolean; fingerprintSha256?: string }>
+  remoteHostTrustGetLastDecision: (server: RemoteShellServer) => Promise<RemoteHostTrustDecision | null>
 }
 
 // 创建分组 API 适配器
@@ -175,6 +178,11 @@ function createGroupedAPI() {
       testConnection: (server: RemoteShellServer) => raw.remoteShellTestConnection(server),
       upload: (server: RemoteShellServer, remoteDirectory: string) => raw.remoteShellUpload(server, remoteDirectory),
       download: (server: RemoteShellServer, remotePath: string) => raw.remoteShellDownload(server, remotePath),
+    },
+
+    remoteHostTrust: {
+      getStatus: (server: RemoteShellServer) => raw.remoteHostTrustGetStatus(server),
+      getLastDecision: (server: RemoteShellServer) => raw.remoteHostTrustGetLastDecision(server),
     },
 
     // Shell 执行

--- a/src/renderer/shell/components/ShellManagerDialog.tsx
+++ b/src/renderer/shell/components/ShellManagerDialog.tsx
@@ -229,6 +229,21 @@ export function ShellManagerDialog({
   const remoteCount = useMemo(() => formLinks.filter((item) => item.type === 'remote').length, [formLinks])
   const favoriteCount = useMemo(() => formPresets.filter((item) => item.favorite).length + formLinks.filter((item) => item.favorite).length, [formLinks, formPresets])
   const commandCount = useMemo(() => formLinks.filter((item) => item.type === 'command').length, [formLinks])
+  const duplicateRemoteServerNames = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const link of formLinks) {
+      if (link.type !== 'remote') continue
+      const normalized = link.name.trim().toLocaleLowerCase()
+      if (!normalized) continue
+      counts.set(normalized, (counts.get(normalized) || 0) + 1)
+    }
+
+    return formLinks
+      .filter((link) => link.type === 'remote')
+      .map((link) => link.name.trim())
+      .filter((name) => name && (counts.get(name.toLocaleLowerCase()) || 0) > 1)
+      .filter((name, index, array) => array.indexOf(name) === index)
+  }, [formLinks])
 
   const sectionItems = useMemo(() => {
     if (activeSection === 'preset') {
@@ -362,6 +377,11 @@ export function ShellManagerDialog({
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Shell 管理" size="5xl">
       <div className="space-y-6 max-h-[78vh] overflow-y-auto pr-1">
+        {duplicateRemoteServerNames.length > 0 && (
+          <div className="rounded-2xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+            Remote server names should be unique for agent routing. Current duplicates: {duplicateRemoteServerNames.join(', ')}
+          </div>
+        )}
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           <div className="rounded-2xl border border-border/60 bg-surface/50 p-4"><div className="flex items-center gap-2 text-text-primary mb-2"><TerminalSquare className="w-4 h-4 text-accent" /><span className="text-sm font-medium">默认 Shell</span></div><div className="text-sm text-text-secondary break-all">{resolvedDefaultShell}</div></div>
           <div className="rounded-2xl border border-border/60 bg-surface/50 p-4"><div className="flex items-center gap-2 text-text-primary mb-2"><Star className="w-4 h-4 text-accent" /><span className="text-sm font-medium">收藏</span></div><div className="text-2xl font-semibold text-text-primary">{favoriteCount}</div></div>

--- a/src/renderer/shell/services/shellService.ts
+++ b/src/renderer/shell/services/shellService.ts
@@ -40,33 +40,6 @@ class ShellService {
     return requestedCwd || context.selectedRoot || context.workspaceRoots?.[0] || '';
   }
 
-  buildRemoteCommand(server: RemoteServerConfig): string {
-    const host = server.host.trim();
-    const username = server.username?.trim();
-    const login = username ? `${username}@${host}` : host;
-    const port = server.port && server.port > 0 ? server.port : 22;
-    const privateKey = server.privateKeyPath?.trim();
-    const remotePath = server.remotePath?.trim();
-
-    const args: string[] = ['ssh', '-tt', '-o', 'StrictHostKeyChecking=accept-new'];
-    if (port !== 22) args.push('-p', String(port));
-    if (privateKey) args.push('-i', this.quoteShellArg(privateKey));
-    args.push(login);
-    if (remotePath) {
-      args.push(`'cd ${this.escapeSingleQuotes(remotePath)} && exec \${SHELL:-sh} -l'`);
-    }
-
-    return args.join(' ');
-  }
-
-  private quoteShellArg(value: string): string {
-    return `'${this.escapeSingleQuotes(value)}'`;
-  }
-
-  private escapeSingleQuotes(value: string): string {
-    return value.replace(/'/g, `'\\''`);
-  }
-
   async createSession(options: CreateShellSessionOptions) {
     const terminalId = await terminalManager.createTerminal({
       name: options.name,

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -214,6 +214,16 @@ export interface RemoteShellDownloadResult {
   localPath?: string
 }
 
+export type RemoteHostTrustStatus = 'known' | 'accepted_new' | 'mismatch_rejected'
+
+export interface RemoteHostTrustDecision {
+  host: string
+  port: number
+  hostTrustStatus: RemoteHostTrustStatus
+  hostFingerprintSha256: string
+  knownHostFingerprintSha256?: string
+}
+
 export interface EmbeddingConfigInput {
   provider?: 'jina' | 'voyage' | 'openai' | 'cohere' | 'huggingface' | 'ollama' | 'custom'
   apiKey?: string
@@ -480,6 +490,8 @@ export interface ElectronAPI {
   remoteShellTestConnection: (server: RemoteShellServer) => Promise<{ success: boolean; error?: string }>
   remoteShellUpload: (server: RemoteShellServer, remoteDirectory: string) => Promise<RemoteShellUploadResult>
   remoteShellDownload: (server: RemoteShellServer, remotePath: string) => Promise<RemoteShellDownloadResult>
+  remoteHostTrustGetStatus: (server: RemoteShellServer) => Promise<{ known: boolean; fingerprintSha256?: string }>
+  remoteHostTrustGetLastDecision: (server: RemoteShellServer) => Promise<RemoteHostTrustDecision | null>
 
   // Shell
   executeBackground: (params: { command: string; cwd?: string; timeout?: number; shell?: string }) => Promise<{

--- a/src/shared/config/toolGroups.ts
+++ b/src/shared/config/toolGroups.ts
@@ -62,6 +62,13 @@ const CORE_TOOLS: string[] = [
   'delete_file_or_folder',
   // 终端
   'run_command',
+  'list_remote_directory',
+  'read_remote_file',
+  'write_remote_file',
+  'rename_remote_path',
+  'delete_remote_path',
+  'upload_to_remote',
+  'download_from_remote',
   'get_lint_errors',
   // 代码智能
   'find_references',

--- a/src/shared/config/tools.ts
+++ b/src/shared/config/tools.ts
@@ -399,10 +399,12 @@ Do not use for partial edits; write_file overwrites the whole file, so use edit_
     run_command: {
         name: 'run_command',
         displayName: 'Run Command',
-        description: 'Execute shell command. Requires user approval. Use cwd parameter to set working directory. Do NOT use for reading files (use read_file), searching (use search_files), or editing (use edit_file).',
+        description: 'Execute shell command locally or on a configured remote server. Requires user approval. Use cwd parameter to set working directory for local runs. Do NOT use for reading files (use read_file/read_remote_file), searching (use search_files), or editing (use edit_file/write_remote_file).',
         detailedDescription: `Execute shell commands in workspace.
 - Requires user approval
 - Use cwd parameter instead of cd commands
+- To force a remote target, set server_name or rely on an explicit #server-name# mention in the user message
+- Never assume remote file tools and local file tools are interchangeable
 For long-running servers or watch tasks:
 - Set is_background=true to run in a UI terminal panel
 - The command returns a terminal ID immediately
@@ -433,8 +435,182 @@ For long-running servers or watch tasks:
         parameters: {
             command: { type: 'string', description: 'Shell command', required: true },
             cwd: { type: 'string', description: 'Working directory relative to workspace root (e.g., "packages/core", NOT "./packages/core")', },
+            server_name: { type: 'string', description: 'Optional remote server name from Shell Studio. When set, command must run on that remote server instead of locally.' },
             timeout: { type: 'number', description: 'Timeout seconds (default: 60). Increase for slow commands like installs.', default: 60 },
             is_background: { type: 'boolean', description: 'Run in background as a visible UI terminal. Required for long-running processes like servers or watchers.', default: false },
+        },
+    },
+
+    list_remote_directory: {
+        name: 'list_remote_directory',
+        displayName: 'List Remote Directory',
+        description: 'List files and folders on a remote server via Shell Studio remote connections. Never use for local files.',
+        detailedDescription: `List one directory level on a remote server.
+- Resolves the remote target from server_name, #server-name#, or recent remote memory
+- Uses remote SFTP capabilities only
+- Never falls back to local listing`,
+        category: 'read',
+        approvalType: 'none',
+        parallel: true,
+        concurrencyMode: 'parallel-safe',
+        resourceScope: ['remote:filesystem:list'],
+        resultSemantics: 'file-read',
+        retryPolicy: { maxAttempts: 1 },
+        validationLevel: 'schema',
+        requiresWorkspace: false,
+        enabled: true,
+        parameters: {
+            path: { type: 'string', description: 'Remote directory path. Defaults to the server remotePath or "." when omitted.', default: '.' },
+            server_name: { type: 'string', description: 'Optional Shell Studio remote server name.' },
+        },
+    },
+
+    read_remote_file: {
+        name: 'read_remote_file',
+        displayName: 'Read Remote File',
+        description: 'Read a text file from a remote server. Never use for local files.',
+        detailedDescription: `Read a remote text file through Shell Studio remote connections.
+- Resolves the remote target from server_name, #server-name#, or recent remote memory
+- Uses remote SFTP only
+- Never falls back to a local file read`,
+        category: 'read',
+        approvalType: 'none',
+        parallel: true,
+        concurrencyMode: 'parallel-safe',
+        resourceScope: ['remote:filesystem:read'],
+        resultSemantics: 'file-read',
+        retryPolicy: { maxAttempts: 1 },
+        validationLevel: 'schema',
+        requiresWorkspace: false,
+        enabled: true,
+        parameters: {
+            path: { type: 'string', description: 'Remote file path', required: true },
+            server_name: { type: 'string', description: 'Optional Shell Studio remote server name.' },
+        },
+    },
+
+    write_remote_file: {
+        name: 'write_remote_file',
+        displayName: 'Write Remote File',
+        description: 'Create or overwrite a remote text file. Requires approval. Never use for local files.',
+        detailedDescription: `Write text content to a remote file.
+- Requires dangerous approval
+- Resolves the remote target from server_name, #server-name#, or recent remote memory
+- Uses remote SFTP only
+- Never falls back to a local write`,
+        category: 'write',
+        approvalType: 'dangerous',
+        parallel: false,
+        concurrencyMode: 'approval-gated',
+        resourceScope: ['remote:filesystem:write'],
+        resultSemantics: 'file-write',
+        retryPolicy: { maxAttempts: 1 },
+        validationLevel: 'schema',
+        requiresWorkspace: false,
+        enabled: true,
+        parameters: {
+            path: { type: 'string', description: 'Remote file path', required: true },
+            content: { type: 'string', description: 'Full file content to write', required: true },
+            server_name: { type: 'string', description: 'Optional Shell Studio remote server name.' },
+        },
+    },
+
+    rename_remote_path: {
+        name: 'rename_remote_path',
+        displayName: 'Rename Remote Path',
+        description: 'Rename or move a remote file or directory. Requires approval.',
+        detailedDescription: `Rename or move a remote file or folder.
+- Requires dangerous approval
+- Uses remote SFTP only
+- Never falls back to a local rename`,
+        category: 'write',
+        approvalType: 'dangerous',
+        parallel: false,
+        concurrencyMode: 'approval-gated',
+        resourceScope: ['remote:filesystem:write'],
+        resultSemantics: 'file-write',
+        retryPolicy: { maxAttempts: 1 },
+        validationLevel: 'schema',
+        requiresWorkspace: false,
+        enabled: true,
+        parameters: {
+            old_path: { type: 'string', description: 'Existing remote path', required: true },
+            new_path: { type: 'string', description: 'New remote path', required: true },
+            server_name: { type: 'string', description: 'Optional Shell Studio remote server name.' },
+        },
+    },
+
+    delete_remote_path: {
+        name: 'delete_remote_path',
+        displayName: 'Delete Remote Path',
+        description: 'Delete a remote file or directory recursively. Requires approval.',
+        detailedDescription: `Delete a remote file or directory.
+- Requires dangerous approval
+- Uses remote SFTP only
+- Never falls back to a local delete`,
+        category: 'write',
+        approvalType: 'dangerous',
+        parallel: false,
+        concurrencyMode: 'approval-gated',
+        resourceScope: ['remote:filesystem:write'],
+        resultSemantics: 'file-write',
+        retryPolicy: { maxAttempts: 1 },
+        validationLevel: 'schema',
+        requiresWorkspace: false,
+        enabled: true,
+        parameters: {
+            path: { type: 'string', description: 'Remote file or directory path', required: true },
+            server_name: { type: 'string', description: 'Optional Shell Studio remote server name.' },
+        },
+    },
+
+    upload_to_remote: {
+        name: 'upload_to_remote',
+        displayName: 'Upload To Remote',
+        description: 'Open the native file picker and upload one or more local files to a remote directory. Requires approval.',
+        detailedDescription: `Upload local files to a remote directory.
+- Requires dangerous approval
+- Opens the desktop file picker for the user to choose local files
+- Uses remote SFTP only
+- Never writes into the local workspace on fallback`,
+        category: 'write',
+        approvalType: 'dangerous',
+        parallel: false,
+        concurrencyMode: 'approval-gated',
+        resourceScope: ['remote:filesystem:write'],
+        resultSemantics: 'file-write',
+        retryPolicy: { maxAttempts: 1 },
+        validationLevel: 'schema',
+        requiresWorkspace: false,
+        enabled: true,
+        parameters: {
+            path: { type: 'string', description: 'Remote destination directory. Defaults to the server remotePath or "." when omitted.', default: '.' },
+            server_name: { type: 'string', description: 'Optional Shell Studio remote server name.' },
+        },
+    },
+
+    download_from_remote: {
+        name: 'download_from_remote',
+        displayName: 'Download From Remote',
+        description: 'Download a remote file through the native save dialog. Requires approval.',
+        detailedDescription: `Download a remote file to the local machine.
+- Requires dangerous approval
+- Opens the desktop save dialog for the user to choose the local destination
+- Uses remote SFTP only
+- Never falls back to a local file copy`,
+        category: 'write',
+        approvalType: 'dangerous',
+        parallel: false,
+        concurrencyMode: 'approval-gated',
+        resourceScope: ['remote:filesystem:write'],
+        resultSemantics: 'file-write',
+        retryPolicy: { maxAttempts: 1 },
+        validationLevel: 'schema',
+        requiresWorkspace: false,
+        enabled: true,
+        parameters: {
+            path: { type: 'string', description: 'Remote file path to download', required: true },
+            server_name: { type: 'string', description: 'Optional Shell Studio remote server name.' },
         },
     },
 

--- a/tests/main/security/secureTerminal.test.ts
+++ b/tests/main/security/secureTerminal.test.ts
@@ -116,4 +116,3 @@ describe('secureTerminal', () => {
     expect(childSpawnMock).toHaveBeenCalledTimes(1)
   })
 })
-


### PR DESCRIPTION
## Summary

Closes #99

把 Shell Studio 中维护的远程服务器真正接到 Agent 远程工具链上，同时补齐首次 SSH 主机信任的产品化行为，解决此前“服务器配置存在但 Agent 无法稳定理解 / 复用 / 安全执行”的割裂问题。

本 PR 主要包含：

- 支持在对话中通过 `#服务器名#` 显式指定 Shell Studio 远程服务器
- 在线程中持久化 `lastActiveServer`，让多轮远程任务能保守复用最近一次远程上下文
- 增加统一的远程路由服务，统一处理 `server_name`、显式 `#服务器名#`、最近服务器记忆与本地默认回退
- 为 `run_command` 接入远程目标路由，并按服务器维度复用 Agent 自己的远程终端 `Agent · <serverName>`
- 增加远程文件工具：目录列出、读取、写入、重命名、删除、上传、下载
- 新增主进程 `RemoteHostTrustService`，把未知主机首次自动接受、后续静默通过、指纹变化拒绝的逻辑统一收口到 Adnify 自己维护的 `known_hosts.json`
- 让 Agent 远程命令、远程文件工具、Shell Studio 手动远程会话共用同一套 SSH trust 逻辑，不再暴露底层 `yes/no` 指纹交互
- 在工具卡 / 错误卡中展示本地或远程执行目标、命中服务器、路由来源，以及首次信任 / 指纹冲突信息

## Details

### 路由与上下文

- 在 ChatPanel / MentionParser 中为 `#...#` 增加远程服务器匹配能力
- 新增 `ShellServerContext` 与线程级 `lastActiveServer`
- Prompt 注入安全裁剪后的远程服务器清单，并明确约束远程工具与本地工具不能相互替代，远程失败不得静默回退本地

### 工具与执行

- `run_command` 新增 `server_name` 路由参数
- 新增 `list_remote_directory`、`read_remote_file`、`write_remote_file`、`rename_remote_path`、`delete_remote_path`、`upload_to_remote`、`download_from_remote`
- 所有远程工具结果统一补充 `executionTarget`、`serverName`、`resolvedBy`、`hostTrustStatus`、`hostFingerprintSha256`

### SSH trust

- 新增应用级 `RemoteHostTrustService`
- 存储位置固定为 app userData 下的 `ssh/known_hosts.json`
- 首次未知主机自动写入，已知主机静默通过，指纹变化明确拒绝并返回旧/新 fingerprint
- 删除 renderer 里遗留的原始 `ssh -tt / StrictHostKeyChecking=accept-new` 执行思路，避免未来重新接回不一致链路

## Validation

- `pnpm exec tsc --noEmit`

当前仍有仓库里既有的类型检查问题，和本 PR 无关：

- `src/main/services/documentReader/richContentReader.ts` / `tests/main/documentReader.test.ts` 缺少 `jszip` 类型声明
- `tests/agent/tools/documentReadTools.test.ts` 存在未使用变量 `zh`
