### PR TITLE
收敛文件工具语义并修正 write_file 展示状态

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Join our community to discuss Adnify usage and development!
 
 - **24+ Built-in Native Core Tools**: Building a universal foundation allowing AI to fully take over projects
   - 📂 **File System Management**: `read_file` (supports single/batch file reading), `list_directory` (supports recursive traversal)
-  - ✍️ **Smart Code Editing**: `edit_file` (9-strategy intelligent matching), `write_file`, `create_file_or_folder`, `delete_file_or_folder`
+- ✍️ **Smart Code Editing**: `edit_file` (9-strategy intelligent matching), `write_file`, `create_directory`, `delete_file_or_folder`
   - 🔎 **Full-scale Search Engine**: `search_files` (ultra-fast regex scan, supports | pattern combination), `codebase_search` (LanceDB vector semantic insight)
   - 🧠 **Language Service (LSP)**: `find_references`, `go_to_definition`, `get_hover_info`, `get_document_symbols`, `get_lint_errors` (supports force refresh)
   - 💻 **Sandbox Terminal Control**: `run_command` (supports background execution), `read_terminal_output`, `send_terminal_input` (supports Ctrl key combinations), `stop_terminal`

--- a/README_CN.md
+++ b/README_CN.md
@@ -151,7 +151,7 @@ Adnify 不仅仅是一个编辑器，它是你的**智能编程伴侣**。它复
 
 - **24+ 个内置原生核心工具**: 构建出让 AI 可以完全接管项目的泛用型底座能力
   - 📂 **文件系统管理**: `read_file` (支持单文件/多文件批量读取), `list_directory` (支持递归遍历)
-  - ✍️ **智能代码编辑**: `edit_file` (9 策略智能匹配), `write_file`, `create_file_or_folder`, `delete_file_or_folder`
+- ✍️ **智能代码编辑**: `edit_file` (9 策略智能匹配), `write_file`, `create_directory`, `delete_file_or_folder`
   - 🔎 **全量检索引擎**: `search_files` (超高速正则扫描，支持 | 组合多模式), `codebase_search` (基于 LanceDB 向量的语义洞察)
   - 🧠 **语言服务层 (LSP)**: `find_references`, `go_to_definition`, `get_hover_info`, `get_document_symbols`, `get_lint_errors` (支持强制刷新)
   - 💻 **底层沙盒终端控制**: `run_command` (支持后台运行), `read_terminal_output`, `send_terminal_input` (支持 Ctrl 组合键), `stop_terminal`

--- a/src/renderer/agent/domains/context/CompressionManager.ts
+++ b/src/renderer/agent/domains/context/CompressionManager.ts
@@ -53,7 +53,7 @@ export const LEVEL_NAMES = [
 ] as const
 
 /** 需要截断参数的工具 */
-const TRUNCATE_TOOLS = new Set(['write_file', 'edit_file', 'create_file_or_folder'])
+const TRUNCATE_TOOLS = new Set(['write_file', 'edit_file'])
 
 /** 受保护的工具（不清理结果） */
 const PROTECTED_TOOLS = new Set(['ask_user'])

--- a/src/renderer/agent/domains/context/summaryService.ts
+++ b/src/renderer/agent/domains/context/summaryService.ts
@@ -568,6 +568,9 @@ function extractCompletedSteps(messages: ChatMessage[]): string[] {
         case 'create_file':
           steps.push(`Created file: ${args.path}`)
           break
+        case 'create_directory':
+          steps.push(`Created directory: ${args.path}`)
+          break
         case 'edit_file':
           steps.push(`Modified file: ${args.path}`)
           break

--- a/src/renderer/agent/prompts/promptTemplates.ts
+++ b/src/renderer/agent/prompts/promptTemplates.ts
@@ -177,6 +177,7 @@ You are an AUTONOMOUS agent. This means:
 - For multi-document writing tasks (for example merging several .md/.txt plans), read all source documents first, then write once after the full context is available
 - For large files, prefer line-mode or batched edits; avoid huge old_string blocks and repeated full rewrites
 - Use write_file only for new files or intentional full rewrites; use edit_file for any partial change to an existing file
+- Use create_directory only for creating folders/directories
 - After one failed large-file edit, change strategy instead of retrying the same oversized payload
 
 ### Handling Failures
@@ -257,6 +258,7 @@ DO NOT make parallel edits to the SAME file.
 ### Write vs Edit Selection
 
 - \`write_file\`: only for new files, near-total rewrites, or deliberate full regeneration
+- \`create_directory\`: only for creating folders/directories
 - \`edit_file\`: for any partial modification to an existing file
 - Small, unique local change 鈫?use \`edit_file\` string mode
 - Known line range or large file 鈫?use \`edit_file\` line mode

--- a/src/renderer/agent/tools/executors.ts
+++ b/src/renderer/agent/tools/executors.ts
@@ -1013,7 +1013,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
         }
 
         if (hasLineMode) {
-            // 行模式（原 replace_file_content）
+            // 行模式
             const { start_line: startLine, end_line: endLine, content } = resolution.args
 
             // 验证缓存
@@ -1288,79 +1288,21 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
         }
     },
 
-    async create_file_or_folder(args, ctx) {
+    async create_directory(args, ctx) {
         const path = resolvePath(args.path, ctx.workspacePath)
-        const isFolder = path.endsWith('/') || path.endsWith('\\')
-
-        if (isFolder) {
-            const success = await api.file.mkdir(path)
-            if (success) {
-                notifyWorkspaceTreeChange({
-                    workspacePath: ctx.workspacePath || '',
-                    targetPath: path,
-                    changeType: 'create',
-                    isDirectory: true,
-                })
-            }
-            return { success, result: success ? 'Folder created' : 'Failed to create folder' }
-        }
-
-        const originalContent = await api.file.read(path)
-        const content = (args.content as string) || ''
-        const guardedWrite = await guardedWriteFile({
-            path,
-            nextContent: content,
-            originalContent,
-            staleMessage: 'Create file conflict detected: target path changed before creation completed',
-        })
-
-        if (guardedWrite.success) {
-            // 通知 LSP 并等待诊断
-            await notifyLspAfterWrite(path, content)
-
-            notifyComposerChange({
-                filePath: path,
+        const normalizedPath = path.endsWith('/') || path.endsWith('\\')
+            ? path.slice(0, -1)
+            : path
+        const success = await api.file.mkdir(normalizedPath)
+        if (success) {
+            notifyWorkspaceTreeChange({
                 workspacePath: ctx.workspacePath || '',
-                oldContent: null,
-                newContent: content,
+                targetPath: normalizedPath,
                 changeType: 'create',
-                linesAdded: content.split('\n').length,
-                linesRemoved: 0,
-                ...getWritePreviewFlags(null, content),
-                toolCallId: ctx.toolCallId
-            })
-
-            await aiAttributionService.recordWriteEvent({
-                workspacePath: ctx.workspacePath || null,
-                filePath: path,
-                toolName: 'create_file_or_folder',
-                toolCallId: ctx.toolCallId,
-                threadId: ctx.threadId,
-                assistantId: ctx.currentAssistantId ?? ctx.assistantId,
-                requestId: ctx.requestId,
-                oldContent: originalContent || '',
-                newContent: content,
-                preHash: guardedWrite.meta.preHash,
-                postHash: guardedWrite.meta.postHash,
-                linesAdded: countLinesFast(content),
-                linesRemoved: 0,
+                isDirectory: true,
             })
         }
-
-        if (!guardedWrite.success) return guardedWrite.result
-
-        return {
-            success: true,
-            result: 'File created',
-            meta: buildWriteMeta(
-                path,
-                null,
-                content,
-                { added: countLinesFast(content), removed: 0 },
-                guardedWrite.meta,
-                { isNewFile: true }
-            )
-        }
+        return { success, result: success ? 'Directory created' : 'Failed to create directory' }
     },
 
     async delete_file_or_folder(args, ctx) {
@@ -2338,7 +2280,7 @@ export const toolExecutors = Object.fromEntries(
     Object.entries(rawToolExecutors).map(([name, executor]) => [
         name,
         async (args: Record<string, unknown>, ctx: ToolExecutionContext): Promise<ToolExecutionResult> => {
-            const timeoutMs = ['generate_tests', 'run_command', 'edit_file', 'replace_file_content', 'web_search'].includes(name) ? 120000 : 60000
+            const timeoutMs = ['generate_tests', 'run_command', 'edit_file', 'web_search'].includes(name) ? 120000 : 60000
             let timer: ReturnType<typeof setTimeout>
 
             try {

--- a/src/renderer/agent/utils/EditRetryStrategy.ts
+++ b/src/renderer/agent/utils/EditRetryStrategy.ts
@@ -358,7 +358,7 @@ export function generateFixSuggestion(
       return `Multiple matches found for the text. To fix:\n` +
         `1. Include more context (2-3 lines before and after the change)\n` +
         `2. Or use \`replace_all=true\` if you want to replace all occurrences\n` +
-        `3. Or use \`replace_file_content\` with specific line numbers`
+        `3. Or use \`edit_file\` line mode with specific line numbers`
 
     case 'file_not_found':
       return `File ${path} does not exist. Use \`write_file\` to create it.`

--- a/src/renderer/agent/utils/LoopDetector.ts
+++ b/src/renderer/agent/utils/LoopDetector.ts
@@ -86,8 +86,7 @@ const READ_OPERATIONS = new Set([
 const WRITE_OPERATIONS = new Set([
   'edit_file',
   'write_file',
-  'replace_file_content',
-  'create_file_or_folder',
+  'create_directory',
   'delete_file_or_folder',
   'run_command',
 ])

--- a/src/renderer/agent/utils/fileWriteDisplay.ts
+++ b/src/renderer/agent/utils/fileWriteDisplay.ts
@@ -1,0 +1,58 @@
+export type WriteIntentLike = 'create' | 'full-rewrite' | 'partial-update'
+export type FileChangeActionLabel = 'Create' | 'Rewrite' | 'Update'
+
+function normalizeWriteIntent(meta?: Record<string, unknown>): WriteIntentLike | null {
+  const value = meta?.writeIntent
+  if (value === 'create' || value === 'full-rewrite' || value === 'partial-update') {
+    return value
+  }
+  return null
+}
+
+export function resolveFileChangeActionLabel(
+  toolName: string,
+  meta?: Record<string, unknown>,
+  oldContent = '',
+  newContent = ''
+): FileChangeActionLabel {
+  if (toolName === 'edit_file') {
+    return 'Update'
+  }
+
+  if (toolName === 'write_file') {
+    const writeIntent = normalizeWriteIntent(meta)
+    if (writeIntent === 'create') return 'Create'
+    if (writeIntent === 'full-rewrite') return 'Rewrite'
+    return !oldContent && !!newContent ? 'Create' : 'Rewrite'
+  }
+
+  return !oldContent && !!newContent ? 'Create' : 'Update'
+}
+
+export function isCreateActionLabel(label: FileChangeActionLabel): boolean {
+  return label === 'Create'
+}
+
+export function resolveWriteFileStatusText(
+  meta: Record<string, unknown> | undefined,
+  oldContent = '',
+  newContent = '',
+  tense: 'running' | 'success' | 'error',
+  path: string
+): string {
+  const action = resolveFileChangeActionLabel('write_file', meta, oldContent, newContent)
+  const actionText =
+    tense === 'running'
+      ? (action === 'Create' ? 'Creating' : 'Rewriting')
+      : tense === 'success'
+        ? (action === 'Create' ? 'Created' : 'Rewritten')
+        : (action === 'Create' ? 'Failed to create' : 'Failed to rewrite')
+
+  if (!path) {
+    return tense === 'running'
+      ? (action === 'Create' ? 'Creating...' : 'Rewriting...')
+      : actionText
+  }
+
+  return `${actionText} ${path}`
+}

--- a/src/renderer/components/agent/FileChangeCard.tsx
+++ b/src/renderer/components/agent/FileChangeCard.tsx
@@ -13,6 +13,7 @@ import { useStore } from '@store'
 import { useShallow } from 'zustand/react/shallow'
 import { api } from '@/renderer/services/electronAPI'
 import { toast } from '@components/common/ToastProvider'
+import { isCreateActionLabel, resolveFileChangeActionLabel } from '@renderer/agent/utils/fileWriteDisplay'
 
 interface FileChangeCardProps {
     toolCall: ToolCall
@@ -142,8 +143,10 @@ function FileChangeCard({
         }
     }, [oldContent, newContent, meta, isRunning, isStreaming])
 
-    const isNewFile = ['create_file', 'create_file_or_folder'].includes(toolCall.name) ||
-        (!oldContent && !!newContent && !['edit_file', 'replace_file_content', 'write_file'].includes(toolCall.name))
+    const changeLabel = useMemo(() => (
+        resolveFileChangeActionLabel(toolCall.name, meta, oldContent, newContent)
+    ), [toolCall.name, meta, oldContent, newContent])
+    const isCreateAction = isCreateActionLabel(changeLabel)
     // Card style only; visual design remains unchanged.
     const cardStyle = useMemo(() => {
         if (isAwaitingApproval) return 'border-l-2 border-yellow-500 bg-yellow-500/5'
@@ -247,10 +250,10 @@ function FileChangeCard({
                                 <span
                                     className={`text-[12px] truncate transition-colors ${isStreaming || isRunning ? 'text-text-primary' : 'text-text-secondary group-hover:text-text-primary'}`}
                                 >
-                                    {isNewFile ? 'Create ' : 'Update '}
+                                    {changeLabel}{' '}
                                 </span>
                                 <span
-                                    className={`${isNewFile ? 'text-status-success' : 'text-text-primary'} ${isStreaming || isRunning ? 'tool-text-shimmer text-[12px] font-medium' : 'font-medium text-[12px]'} hover:underline hover:text-accent cursor-pointer transition-colors break-all`}
+                                    className={`${isCreateAction ? 'text-status-success' : 'text-text-primary'} ${isStreaming || isRunning ? 'tool-text-shimmer text-[12px] font-medium' : 'font-medium text-[12px]'} hover:underline hover:text-accent cursor-pointer transition-colors break-all`}
                                     onClick={(e) => {
                                         e.stopPropagation()
                                         if (isLargeWrite) {
@@ -298,7 +301,7 @@ function FileChangeCard({
                                 {diffStats.removed > 0 && (
                                     <span className="text-red-400">-{diffStats.removed}</span>
                                 )}
-                                {isNewFile && diffStats.added === 0 && (
+                                {isCreateAction && diffStats.added === 0 && (
                                     <span className="text-blue-400">new</span>
                                 )}
                             </span>

--- a/src/renderer/components/agent/ToolCallCard.tsx
+++ b/src/renderer/components/agent/ToolCallCard.tsx
@@ -17,6 +17,7 @@ import { TextWithFileLinks } from '../common/TextWithFileLinks'
 import { SyntaxHighlighter } from '@renderer/utils/syntaxHighlighter'
 import { themeManager } from '../../config/themeConfig'
 import { writeClipboardText } from '@/renderer/services/clipboardService'
+import { resolveWriteFileStatusText } from '@renderer/agent/utils/fileWriteDisplay'
 
 interface ToolCallCardProps {
     toolCall: ToolCall
@@ -37,8 +38,8 @@ const TOOL_LABELS: Record<string, string> = {
     codebase_search: 'Semantic Search',
     edit_file: 'Edit File',
     write_file: 'Write File',
+    create_directory: 'Create Directory',
     create_file: 'Create File',
-    create_file_or_folder: 'Create',
     delete_file_or_folder: 'Delete',
     run_command: 'Run Command',
     get_lint_errors: 'Lint Errors',
@@ -163,7 +164,19 @@ function getStatusText(name: string, args: ToolArgs, status: ToolCall['status'],
         return `Reading ${path}`
     }
 
-    if (['write_file', 'create_file', 'create_file_or_folder'].includes(name)) {
+    if (name === 'write_file') {
+        const meta = args._meta && typeof args._meta === 'object' ? args._meta as Record<string, unknown> : undefined
+        const oldContent = typeof meta?.oldContent === 'string' ? meta.oldContent : ''
+        const newContent = typeof meta?.newContent === 'string'
+            ? meta.newContent
+            : (typeof args.content === 'string' ? args.content : '')
+        if (isRunning) return resolveWriteFileStatusText(meta, oldContent, newContent, 'running', path)
+        if (isSuccess) return resolveWriteFileStatusText(meta, oldContent, newContent, 'success', path)
+        if (isError) return resolveWriteFileStatusText(meta, oldContent, newContent, 'error', path)
+        return resolveWriteFileStatusText(meta, oldContent, newContent, 'running', path)
+    }
+
+    if (name === 'create_directory' || name === 'create_file') {
         if (!path) return isRunning ? 'Creating...' : ''
         if (isRunning) return `Creating ${path}...`
         if (isSuccess) return `Created ${path}`
@@ -616,11 +629,11 @@ function ToolPreview({
         }
     }
 
-    if (['create_file_or_folder', 'delete_file_or_folder'].includes(effectiveName)) {
+    if (effectiveName === 'create_directory' || effectiveName === 'delete_file_or_folder') {
         const paths = getToolPathList(args)
         const path = paths[0] || ''
         const isDelete = effectiveName === 'delete_file_or_folder'
-        const isFolder = path.endsWith('/')
+        const isFolder = effectiveName === 'create_directory' || path.endsWith('/')
         const displayName = paths.length > 1 ? getPathSummary(paths) : (path ? getPathDisplayName(path) : '<no path>')
 
         return (

--- a/src/shared/config/agentConfig.ts
+++ b/src/shared/config/agentConfig.ts
@@ -212,10 +212,6 @@ export const DEFAULT_AGENT_CONFIG: AgentRuntimeConfig = {
       dependsOn: ['read_file'],
       type: 'sequential',
     },
-    replace_file_content: {
-      dependsOn: ['read_file'],
-      type: 'sequential',
-    },
   },
   // Auto-Context Configuration
   enableAutoContext: true,
@@ -233,4 +229,3 @@ export function getCacheConfig(type: keyof CacheConfigs, override?: Partial<Cach
 export function getToolTruncateConfig(toolName: string): ToolTruncateConfig {
   return TOOL_TRUNCATE_DEFAULTS[toolName] || TOOL_TRUNCATE_DEFAULTS.default
 }
-

--- a/src/shared/config/toolGroups.ts
+++ b/src/shared/config/toolGroups.ts
@@ -57,8 +57,7 @@ const CORE_TOOLS: string[] = [
   // 文件编辑
   'edit_file',
   'write_file',
-  'replace_file_content',
-  'create_file_or_folder',
+  'create_directory',
   'delete_file_or_folder',
   // 终端
   'run_command',

--- a/src/shared/config/tools.ts
+++ b/src/shared/config/tools.ts
@@ -239,7 +239,8 @@ Choose one mode only: string mode (old_string + new_string), line mode (start_li
 Never mix modes, never send empty placeholder edits, and never use edit_file to replace a whole file; use write_file for full replacement.`,
         detailedDescription: `When to use:
 - Use edit_file for partial changes to an existing file after read_file.
-- Use write_file for new files or intentional full-file replacement.
+- Use write_file for new files or intentional full rewrite.
+- Use create_directory when you need a new folder.
 
 Choose one mode:
 - String mode: old_string + new_string for one small unique replacement.
@@ -318,11 +319,11 @@ Avoid:
         name: 'write_file',
         displayName: 'Write File',
         description: `Write complete file content.
-Use for new files, intentional full-file replacement, or generated artifact files.
+Use for new files, intentional full rewrites, or generated artifact files.
 Do not use for partial edits; write_file overwrites the whole file, so use edit_file for targeted changes.`,
         criticalRules: [
             'Overwrites the entire file; use edit_file for partial changes',
-            'Prefer over create_file_or_folder when you have file content ready',
+            'Use write_file to create files; use create_directory to create folders',
             'Do not rewrite the same large file multiple times in one turn unless absolutely necessary',
             'If the file already exists and you are only changing a section, DO NOT use write_file',
         ],
@@ -342,16 +343,16 @@ Do not use for partial edits; write_file overwrites the whole file, so use edit_
         },
     },
 
-    create_file_or_folder: {
-        name: 'create_file_or_folder',
-        displayName: 'Create',
-        description: 'Create file or folder. Path ending with / creates folder.',
-        detailedDescription: `Create new files or directories.
-- Path ending with "/" creates folder
-- Can include initial content for files`,
+    create_directory: {
+        name: 'create_directory',
+        displayName: 'Create Directory',
+        description: 'Create a directory.',
+        detailedDescription: `Create a new directory.
+- Use this tool only for folders/directories
+- Trailing slash is optional`,
         examples: [
-            'create_file_or_folder path="src/utils/"',
-            'create_file_or_folder path="src/config.ts" content="export default {}"',
+            'create_directory path="src/utils"',
+            'create_directory path="src/components/"',
         ],
         category: 'write',
         approvalType: 'none',
@@ -364,8 +365,7 @@ Do not use for partial edits; write_file overwrites the whole file, so use edit_
         requiresWorkspace: true,
         enabled: true,
         parameters: {
-            path: { type: 'string', description: 'Path relative to workspace root (end with / for folder, e.g., "src/utils/" or "src/config.ts")', required: true },
-            content: { type: 'string', description: 'Initial content for files' },
+            path: { type: 'string', description: 'Directory path relative to workspace root. Trailing slash is optional.', required: true },
         },
     },
 
@@ -1038,7 +1038,8 @@ export const FILE_EDIT_DECISION_GUIDE = `
 ## File Editing Decision Guide
 
 **1. Pick the tool**
-- New file or full-file replacement: use \`write_file\`.
+- New file or full rewrite: use \`write_file\`.
+- New directory: use \`create_directory\`.
 - Partial change to an existing file: use \`edit_file\` after \`read_file\`.
 
 **2. Pick exactly one edit_file mode**
@@ -1454,17 +1455,17 @@ export function isWriteTool(toolName: string): boolean {
 
 /** 检查工具是否为文件编辑工具（会产生文件内容变更，不包括删除） */
 export function isFileEditTool(toolName: string): boolean {
-    return ['edit_file', 'write_file', 'create_file_or_folder', 'replace_file_content'].includes(toolName)
+    return ['edit_file', 'write_file'].includes(toolName)
 }
 
 /** 检查工具是否需要保存文件快照（用于撤销功能） */
 export function needsFileSnapshot(toolName: string): boolean {
-    return ['edit_file', 'write_file', 'create_file_or_folder', 'replace_file_content', 'delete_file_or_folder'].includes(toolName)
+    return ['edit_file', 'write_file', 'delete_file_or_folder'].includes(toolName)
 }
 
 /** 检查工具是否需要 Diff 预览（使用 FileChangeCard） */
 export function needsDiffPreview(toolName: string): boolean {
-    return ['edit_file', 'write_file', 'replace_file_content'].includes(toolName)
+    return ['edit_file', 'write_file'].includes(toolName)
 }
 
 /** 获取工具元数据 */

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,7 +37,7 @@ tests/
 │   │   └── executors/
 │   │       ├── file.test.ts
 │   │       ├── command.test.ts
-│   │       └── replace_file_content.test.ts
+│   │       └── batchEdit.test.ts
 │   ├── store/                        # 状态管理
 │   │   ├── AgentStore.test.ts
 │   │   ├── threadSlice.test.ts

--- a/tests/agent/tools/toolDefinitions.test.ts
+++ b/tests/agent/tools/toolDefinitions.test.ts
@@ -55,6 +55,18 @@ describe('Tool Definitions', () => {
       expect(TOOL_CONFIGS.edit_file.name).toBe('edit_file')
     })
 
+    it('should have create_directory in configs', () => {
+      expect(TOOL_CONFIGS.create_directory).toBeDefined()
+      expect(TOOL_CONFIGS.create_directory.name).toBe('create_directory')
+    })
+
+    it('should not expose removed file tools', () => {
+      expect(TOOL_CONFIGS.create_file_or_folder).toBeUndefined()
+      expect(TOOL_CONFIGS.replace_file_content).toBeUndefined()
+      expect(TOOL_SCHEMAS.create_file_or_folder).toBeUndefined()
+      expect(TOOL_SCHEMAS.replace_file_content).toBeUndefined()
+    })
+
     it('should have run_command in configs', () => {
       expect(TOOL_CONFIGS.run_command).toBeDefined()
       expect(TOOL_CONFIGS.run_command.name).toBe('run_command')
@@ -101,6 +113,15 @@ describe('Tool Definitions', () => {
       expect(readImageSchema.safeParse({ path: 'images/ui.png' }).success).toBe(true)
       expect(readImageSchema.safeParse({ path: 'images/ui.png', prompt: 'Extract chart labels' }).success).toBe(true)
       expect(readImageSchema.safeParse({}).success).toBe(false)
+    })
+
+    it('should validate create_directory path', () => {
+      const createDirectorySchema = TOOL_SCHEMAS.create_directory
+      expect(createDirectorySchema).toBeDefined()
+
+      expect(createDirectorySchema.safeParse({ path: 'src/utils' }).success).toBe(true)
+      expect(createDirectorySchema.safeParse({ path: 'src/utils/' }).success).toBe(true)
+      expect(createDirectorySchema.safeParse({}).success).toBe(false)
     })
 
     it('should ignore placeholder line fields and empty edits in edit_file string mode', () => {

--- a/tests/agent/utils/fileWriteDisplay.test.ts
+++ b/tests/agent/utils/fileWriteDisplay.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isCreateActionLabel,
+  resolveFileChangeActionLabel,
+  resolveWriteFileStatusText,
+} from '@/renderer/agent/utils/fileWriteDisplay'
+
+describe('fileWriteDisplay', () => {
+  it('renders update for edit_file', () => {
+    expect(resolveFileChangeActionLabel('edit_file', undefined, 'old', 'new')).toBe('Update')
+  })
+
+  it('renders create for write_file create intent', () => {
+    expect(resolveFileChangeActionLabel('write_file', { writeIntent: 'create' }, '', 'new')).toBe('Create')
+  })
+
+  it('renders rewrite for write_file full rewrite intent', () => {
+    expect(resolveFileChangeActionLabel('write_file', { writeIntent: 'full-rewrite' }, 'old', 'new')).toBe('Rewrite')
+  })
+
+  it('falls back to rewrite for write_file with old content and no intent', () => {
+    expect(resolveFileChangeActionLabel('write_file', undefined, 'old', 'new')).toBe('Rewrite')
+  })
+
+  it('recognizes create label tone', () => {
+    expect(isCreateActionLabel('Create')).toBe(true)
+    expect(isCreateActionLabel('Rewrite')).toBe(false)
+  })
+
+  it('renders create-oriented write_file statuses', () => {
+    expect(resolveWriteFileStatusText({ writeIntent: 'create' }, '', 'new', 'running', 'src/new.ts')).toBe('Creating src/new.ts')
+    expect(resolveWriteFileStatusText({ writeIntent: 'create' }, '', 'new', 'success', 'src/new.ts')).toBe('Created src/new.ts')
+    expect(resolveWriteFileStatusText({ writeIntent: 'create' }, '', 'new', 'error', 'src/new.ts')).toBe('Failed to create src/new.ts')
+  })
+
+  it('renders rewrite-oriented write_file statuses', () => {
+    expect(resolveWriteFileStatusText({ writeIntent: 'full-rewrite' }, 'old', 'new', 'running', 'src/app.ts')).toBe('Rewriting src/app.ts')
+    expect(resolveWriteFileStatusText({ writeIntent: 'full-rewrite' }, 'old', 'new', 'success', 'src/app.ts')).toBe('Rewritten src/app.ts')
+    expect(resolveWriteFileStatusText({ writeIntent: 'full-rewrite' }, 'old', 'new', 'error', 'src/app.ts')).toBe('Failed to rewrite src/app.ts')
+  })
+})


### PR DESCRIPTION
## 概述
这个 PR 主要做两件事：一是收敛 agent 的文件写入工具语义，二是让 UI 展示与执行层真实语义保持一致。

## 改动内容
- 将文件创建/编辑相关的公开入口收敛为 `edit_file`、`write_file` 和 `create_directory`
- 移除遗留的 `create_file_or_folder` / `replace_file_content` 运行时路径，并同步更新 prompt、文档和辅助判断逻辑
- 继续将 `write_file` 严格限定为“新建文件”或“整文件重写”，局部修改仍只能通过 `edit_file` 完成
- 调整文件变更卡片和工具调用卡片的状态展示，让 `write_file` 基于 `writeIntent` 显示 `Create` 或 `Rewrite`，不再误导性地显示为 `Update`
- 增加针对文件写入展示语义的测试覆盖

## 改动意义
之前的 UI 会让人误以为 `write_file` 是一个通用的“更新文件”工具，但执行层实际上已经对它做了更严格的限制。这个 PR 把产品展示和底层约束对齐，能更清晰地区分“整文件重写”和“局部更新”，同时也减少模型和用户对工具语义的误解。

## 验证
- `npx vitest --run tests/agent/utils/fileWriteDisplay.test.ts tests/agent/tools/fileWriteStrategy.test.ts tests/agent/core/tools.test.ts tests/agent/tools/toolDefinitions.test.ts`
- `npm run build`