### PR TITLE
fix: 修复 Windows Git Bash 下 Agent 终端命令执行失败

### DIFF
--- a/src/renderer/agent/tools/executors.ts
+++ b/src/renderer/agent/tools/executors.ts
@@ -1600,11 +1600,6 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
                 : {}
             const terminalShell = terminalManager.getState().terminals.find((terminal) => terminal.id === termId)?.shell
             const terminalShellFamily = detectTerminalShellFamily(terminalShell)
-            const trustMeta = remoteLink
-                ? await buildRemoteTrustMeta(remoteLink.remote, undefined, { preferKnownStatus: reused })
-                : {}
-            const terminalShell = terminalManager.getState().terminals.find((terminal) => terminal.id === termId)?.shell
-            const terminalShellFamily = detectTerminalShellFamily(terminalShell)
 
             // 激活 Agent 终端 tab，让用户看到执行过程
             terminalManager.setActiveTerminal(termId)

--- a/src/renderer/agent/tools/executors.ts
+++ b/src/renderer/agent/tools/executors.ts
@@ -44,6 +44,7 @@ import type {
     RemoteHostTrustDecision,
     RemoteShellServer,
 } from '@/renderer/types/electron'
+import { detectTerminalShellFamily } from '@/renderer/services/terminalShell'
 
 // ===== 辅助函数 =====
 
@@ -1597,6 +1598,13 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
             const trustMeta = remoteLink
                 ? await buildRemoteTrustMeta(remoteLink.remote, undefined, { preferKnownStatus: reused })
                 : {}
+            const terminalShell = terminalManager.getState().terminals.find((terminal) => terminal.id === termId)?.shell
+            const terminalShellFamily = detectTerminalShellFamily(terminalShell)
+            const trustMeta = remoteLink
+                ? await buildRemoteTrustMeta(remoteLink.remote, undefined, { preferKnownStatus: reused })
+                : {}
+            const terminalShell = terminalManager.getState().terminals.find((terminal) => terminal.id === termId)?.shell
+            const terminalShellFamily = detectTerminalShellFamily(terminalShell)
 
             // 激活 Agent 终端 tab，让用户看到执行过程
             terminalManager.setActiveTerminal(termId)
@@ -1614,9 +1622,9 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
                 const bgCmd = remoteLink
                     ? remoteCommand
                     : resolvedCwd
-                    ? (/windows/i.test(navigator.userAgent)
-                        ? `Push-Location "${resolvedCwd}"; ${command}; Pop-Location`
-                        : `(cd "${resolvedCwd}" && ${command})`)
+                    ? (terminalShellFamily === 'posix'
+                        ? `(cd "${resolvedCwd}" && ${command})`
+                        : `Push-Location "${resolvedCwd}"; ${command}; Pop-Location`)
                     : command
                 terminalManager.writeToTerminal(termId, `${bgCmd}\r`)
 

--- a/src/renderer/services/TerminalManager.ts
+++ b/src/renderer/services/TerminalManager.ts
@@ -20,6 +20,8 @@ import { toAppError } from "@shared/utils/errorHandler";
 import { isMac } from "@services/keybindingService";
 import { getInteractiveTerminalBackend } from "@/renderer/agent/tools/commandRuntime";
 import { readClipboardText, writeClipboardText } from "@/renderer/services/clipboardService";
+import { detectTerminalShellFamily } from "@/renderer/services/terminalShell";
+import { shellRegistryService } from "@/renderer/shell/services/shellRegistryService";
 
 // ===== 类型定义 =====
 
@@ -1019,9 +1021,16 @@ class TerminalManagerClass {
       return { terminalId, reused: false }
     }
 
+    const resolvedShell = options?.shell || (await shellRegistryService.load()).defaultShell
+
     // 检查现有 agent 终端是否仍然存活
     if (this.agentTerminalId) {
-      if (this.isReusableAgentTerminal(this.agentTerminalId)) {
+      const existing = this.state.terminals.find(t => t.id === this.agentTerminalId)
+      const shellMismatch = Boolean(
+        resolvedShell && (!existing?.shell || existing.shell !== resolvedShell)
+      )
+
+      if (this.isReusableAgentTerminal(this.agentTerminalId) && !shellMismatch) {
         return { terminalId: this.agentTerminalId, reused: true }
       } else {
         this.agentTerminalId = null
@@ -1037,7 +1046,7 @@ class TerminalManagerClass {
     this.agentTerminalCreating = this.createTerminal({
       name: options?.name || this.getNextAgentTerminalName(),
       cwd,
-      shell: options?.shell,
+      shell: resolvedShell,
       isAgent: true,
     }).then(id => {
       if (!this.isTerminalReady(id)) {
@@ -1352,10 +1361,13 @@ class TerminalManagerClass {
       })
 
       // 必须先订阅，再写命令（避免竞态）
-      const isWindows = /windows/i.test(navigator.userAgent)
+      const terminal = this.state.terminals.find((item) => item.id === termId)
+      const shellFamily = detectTerminalShellFamily(terminal?.shell)
+      const usesPosixSyntax = shellFamily === 'posix'
+      const isPowerShell = !usesPosixSyntax
 
       // PowerShell 5.x 不支持 && 运算符；cmd.exe 的 cd /d 在 PS 里无效（/d 被当位置参数）
-      const sanitizedCommand = isWindows
+      const sanitizedCommand = isPowerShell
         ? command
           .replace(/\s*&&\s*/g, '; ')
           .replace(/\bcd\s+\/[dD]\s+(['"]?)([^;|&\n'"]+)\1/g, 'Push-Location "$2"')
@@ -1363,16 +1375,16 @@ class TerminalManagerClass {
 
       // cwd 参数：Agent 终端复用，需临时切换目录
       const cmdWithCwd = cwd
-        ? (isWindows
-          ? `Push-Location "${cwd}"; ${sanitizedCommand}; Pop-Location`
-          : `(cd "${cwd}" && ${sanitizedCommand})`)
+        ? (usesPosixSyntax
+          ? `(cd "${cwd}" && ${sanitizedCommand})`
+          : `Push-Location "${cwd}"; ${sanitizedCommand}; Pop-Location`)
         : sanitizedCommand
 
       // OSC sentinel 命令（Windows/Unix/macOS 三平台）
-      const sentinelStart = isWindows
+      const sentinelStart = isPowerShell
         ? `Write-Host -NoNewline "$([char]27)]9001;${START_PAYLOAD}$([char]7)"`
         : `printf '\\033]9001;${START_PAYLOAD}\\007'`
-      const sentinelEnd = isWindows
+      const sentinelEnd = isPowerShell
         ? `Write-Host -NoNewline "$([char]27)]9001;${END_PAYLOAD_PREFIX}$LASTEXITCODE$([char]7)"`
         : `printf '\\033]9001;${END_PAYLOAD_PREFIX}'"$?"'\\007'`
 
@@ -1388,10 +1400,10 @@ class TerminalManagerClass {
       // N 的计算：ceil((提示符估算长度 + 完整命令长度) / 终端列数) + 1
       const xtermInst = this.xtermInstances.get(termId)
       const cols = xtermInst?.fitAddon?.proposeDimensions?.()?.cols ?? 80
-      const promptLen = isWindows ? 60 : 35
+      const promptLen = isPowerShell ? 60 : 35
       // 每个清除单元的字面长度（PS 使用 $([char]N) 表达式，Unix 使用 octal 转义）
-      const clearUnit = isWindows ? '$([char]27)[1A$([char]27)[2K' : '\\033[1A\\033[2K'
-      const clearWrapLen = isWindows ? 22 : 10  // "Write-Host -NoNewline \"\"; " 或 "printf ''; "
+      const clearUnit = isPowerShell ? '$([char]27)[1A$([char]27)[2K' : '\\033[1A\\033[2K'
+      const clearWrapLen = isPowerShell ? 22 : 10  // "Write-Host -NoNewline \"\"; " 或 "printf ''; "
       // 两次迭代逼近（消除循环依赖）
       const roughLines = Math.ceil((promptLen + mainCommand.length) / cols)
       const clearOverhead = clearWrapLen + clearUnit.length * roughLines
@@ -1402,12 +1414,12 @@ class TerminalManagerClass {
       // 清除回显后，补打一行"伪提示符 + 原始命令"，让终端看起来像用户手动输入
       // Windows PS double-quoted string 转义：` → ``，" → `"，$ → `$
       // Unix double-quoted string 转义：\ → \\，" → \"，$ → \$，` → \`
-      const displayCmd = isWindows
+      const displayCmd = isPowerShell
         ? command.replace(/`/g, '``').replace(/"/g, '`"').replace(/\$/g, '`$')
         : command.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\$/g, '\\$').replace(/`/g, '\\`')
 
       // 提示符路径：有 cwd 时直接嵌入，否则运行时动态获取当前目录
-      const fakeEchoCmd = isWindows
+      const fakeEchoCmd = isPowerShell
         ? `Write-Host -NoNewline "${clearSeq}"; Write-Host "PS ${cwd ?? '$(Get-Location)'}> ${displayCmd}"`
         : `printf '${clearSeq}'; printf '%s\\n' "${cwd ? cwd.replace(/\\/g, '/') : '$(pwd)'}\\$ ${displayCmd}"`
 

--- a/src/renderer/services/terminalShell.ts
+++ b/src/renderer/services/terminalShell.ts
@@ -1,0 +1,42 @@
+export type TerminalShellFamily = 'powershell' | 'cmd' | 'posix'
+
+function normalizeShellToken(shell?: string): string {
+  const raw = typeof shell === 'string' ? shell.trim().toLowerCase() : ''
+  if (!raw) return ''
+
+  const normalized = raw.replace(/\\/g, '/')
+  const shellToken = normalized.split('/').pop() || normalized
+  return shellToken.replace(/^"+|"+$/g, '')
+}
+
+export function detectTerminalShellFamily(
+  shell?: string,
+  userAgent: string = typeof navigator !== 'undefined' ? navigator.userAgent : '',
+): TerminalShellFamily {
+  const shellToken = normalizeShellToken(shell)
+
+  if (shellToken.includes('powershell') || shellToken === 'pwsh' || shellToken === 'pwsh.exe') {
+    return 'powershell'
+  }
+
+  if (shellToken === 'cmd' || shellToken === 'cmd.exe') {
+    return 'cmd'
+  }
+
+  if (
+    shellToken === 'bash'
+    || shellToken === 'bash.exe'
+    || shellToken === 'sh'
+    || shellToken === 'sh.exe'
+    || shellToken === 'zsh'
+    || shellToken === 'zsh.exe'
+    || shellToken === 'fish'
+    || shellToken === 'fish.exe'
+    || shellToken === 'wsl'
+    || shellToken === 'wsl.exe'
+  ) {
+    return 'posix'
+  }
+
+  return /windows/i.test(userAgent) ? 'powershell' : 'posix'
+}

--- a/tests/services/TerminalManager.test.ts
+++ b/tests/services/TerminalManager.test.ts
@@ -4,6 +4,8 @@ const createMock = vi.fn()
 const writeMock = vi.fn()
 const resizeMock = vi.fn()
 const killMock = vi.fn()
+const settingsGetMock = vi.fn()
+const settingsSetMock = vi.fn()
 let dataHandler: ((event: { id: string; data: string; seq: number; occurredAt: number }) => void) | null = null
 let exitHandler: ((event: { id: string; exitCode: number; signal?: number; seq: number; occurredAt: number; reason: 'process_exit' | 'killed_by_user' | 'remote_close' }) => void) | null = null
 
@@ -25,6 +27,10 @@ vi.mock('@renderer/services/electronAPI', () => ({
       onError: vi.fn((_handler) => {
         return () => {}
       }),
+    },
+    settings: {
+      get: settingsGetMock,
+      set: settingsSetMock,
     },
   },
 }))
@@ -103,6 +109,10 @@ describe('TerminalManager command sessions', () => {
     writeMock.mockReset()
     resizeMock.mockReset()
     killMock.mockReset()
+    settingsGetMock.mockReset()
+    settingsGetMock.mockResolvedValue(null)
+    settingsSetMock.mockReset()
+    settingsSetMock.mockResolvedValue(undefined)
     dataHandler = null
     exitHandler = null
     vi.useFakeTimers()
@@ -178,6 +188,33 @@ describe('TerminalManager command sessions', () => {
       expect(resizeMock).not.toHaveBeenCalled()
     } finally {
       terminalManager.cleanup()
+    }
+  })
+
+  it('uses the configured Git Bash shell for agent terminals on Windows hosts', async () => {
+    vi.stubGlobal('navigator', { userAgent: 'Windows NT 10.0' })
+    settingsGetMock.mockResolvedValue({
+      defaultShell: 'C:\\Program Files\\Git\\bin\\bash.exe',
+      presets: [],
+      links: [],
+    })
+    const { terminalManager } = await import('@renderer/services/TerminalManager')
+
+    const resultPromise = terminalManager
+      .getOrCreateAgentTerminal('/tmp/adnify-agent')
+      .then((termId) => terminalManager.executeCommandWithOutput(termId, 'ps -ef', 5000, '/home'))
+
+    try {
+      await vi.waitFor(() => expect(writeMock).toHaveBeenCalledTimes(1))
+      expect(createMock.mock.calls[0]?.[0]?.shell).toBe('C:\\Program Files\\Git\\bin\\bash.exe')
+      const wrapped = writeMock.mock.calls[0]?.[1] as string
+
+      expect(wrapped).toContain("printf '\\033]9001;ADNIFY_CMD_START_")
+      expect(wrapped).toContain('(cd "/home" && ps -ef)')
+      expect(wrapped).not.toContain('Write-Host -NoNewline')
+    } finally {
+      terminalManager.cleanup()
+      await resultPromise
     }
   })
 })

--- a/tests/services/terminalShell.test.ts
+++ b/tests/services/terminalShell.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectTerminalShellFamily } from '@renderer/services/terminalShell'
+
+describe('detectTerminalShellFamily', () => {
+  it('treats Git Bash on Windows as a POSIX shell', () => {
+    expect(detectTerminalShellFamily('C:\\Program Files\\Git\\bin\\bash.exe', 'Windows NT 10.0')).toBe('posix')
+  })
+
+  it('keeps PowerShell shells on the PowerShell code path', () => {
+    expect(detectTerminalShellFamily('powershell.exe', 'Windows NT 10.0')).toBe('powershell')
+    expect(detectTerminalShellFamily('pwsh.exe', 'Windows NT 10.0')).toBe('powershell')
+  })
+
+  it('falls back to the host platform only when the shell is unknown', () => {
+    expect(detectTerminalShellFamily('', 'Windows NT 10.0')).toBe('powershell')
+    expect(detectTerminalShellFamily('', 'Macintosh')).toBe('posix')
+  })
+})


### PR DESCRIPTION
## 问题

- 在 Windows 上将默认 shell 配置为 Git Bash 时，Agent 终端执行路径仍然按 PowerShell 语法包装命令。
- 连接远程服务器后，这些 PowerShell 包装片段会被 POSIX shell 直接解释，导致命令无法正常执行。
- Agent 终端复用时没有继承当前配置的默认 shell，用户即使已经切换到 Git Bash，也可能继续复现这个问题。

## 解决方案

- 新增终端 shell family 检测，明确区分 PowerShell、cmd 和 POSIX shell，而不是仅根据宿主平台判断。
- 调整 Agent 终端创建与复用逻辑，在本地终端场景下读取并使用已配置的默认 shell；如果当前复用终端的 shell 与配置不一致，则重新创建正确的终端。
- 统一命令包装逻辑，在 Git Bash 等 POSIX shell 下使用 POSIX 语法，在 PowerShell 下保留原有包装方式。
- 补充 Windows + Git Bash 场景的回归测试，覆盖 shell 检测和 Agent 终端执行两条关键路径。

## 验证

- `pnpm vitest run tests/services/terminalShell.test.ts tests/services/TerminalManager.test.ts`
- `npm run build`