### PR TITLE
修复智能体工具超时配置未统一生效

### DIFF
--- a/src/renderer/agent/tools/executors.ts
+++ b/src/renderer/agent/tools/executors.ts
@@ -2837,7 +2837,7 @@ export const toolExecutors = Object.fromEntries(
     Object.entries(rawToolExecutors).map(([name, executor]) => [
         name,
         async (args: Record<string, unknown>, ctx: ToolExecutionContext): Promise<ToolExecutionResult> => {
-            const timeoutMs = ['generate_tests', 'run_command', 'edit_file', 'web_search'].includes(name) ? 120000 : 60000
+            const timeoutMs = getAgentConfig().toolTimeoutMs
             let timer: ReturnType<typeof setTimeout>
 
             try {

--- a/src/renderer/agent/tools/providers/McpToolProvider.ts
+++ b/src/renderer/agent/tools/providers/McpToolProvider.ts
@@ -8,6 +8,7 @@ import { toAppError } from '@shared/utils/errorHandler'
 import { mcpService } from '@services/mcpService'
 import { logger } from '@utils/Logger'
 import { getFileName } from '@shared/utils/pathUtils'
+import { getAgentConfig } from '../../utils/AgentConfig'
 import type { ToolProvider } from './types'
 import type {
   ToolDefinition,
@@ -199,7 +200,7 @@ export class McpToolProvider implements ToolProvider {
         serverId,
         toolName: actualToolName,
         arguments: args,
-      })
+      }, getAgentConfig().toolTimeoutMs)
 
       if (!result.success) {
         return {

--- a/tests/agent/tools/mcpToolProvider.test.ts
+++ b/tests/agent/tools/mcpToolProvider.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@renderer/services/mcpService', () => ({
+  mcpService: {
+    callTool: vi.fn().mockResolvedValue({ success: true, content: [], isError: false }),
+  },
+}))
+
+vi.mock('@renderer/agent/utils/AgentConfig', () => ({
+  getAgentConfig: vi.fn(() => ({
+    toolTimeoutMs: 4321,
+  })),
+}))
+
+vi.mock('@renderer/store', () => ({
+  useStore: {
+    getState: vi.fn(() => ({
+      mcpServers: [
+        {
+          id: 'server-1',
+          status: 'connected',
+          config: { id: 'server-1', name: 'Server 1', autoApprove: [] },
+          tools: [{ name: 'tool-a', inputSchema: { type: 'object', properties: {} } }],
+          resources: [],
+          prompts: [],
+        },
+      ],
+    })),
+  },
+}))
+
+vi.mock('@utils/Logger', () => ({
+  logger: {
+    agent: {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  },
+}))
+
+import { mcpService } from '@renderer/services/mcpService'
+import { McpToolProvider } from '@renderer/agent/tools/providers/McpToolProvider'
+
+describe('McpToolProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes the configured agent tool timeout to mcpService', async () => {
+    const provider = new McpToolProvider()
+    const fullToolName = McpToolProvider.getFullToolName('server-1', 'tool-a')
+    const result = await provider.execute(fullToolName, {}, {} as any)
+
+    expect(result.success).toBe(true)
+    expect(mcpService.callTool).toHaveBeenCalledWith(
+      {
+        serverId: 'server-1',
+        toolName: 'tool-a',
+        arguments: {},
+      },
+      4321,
+    )
+  })
+})

--- a/tests/agent/tools/toolExecutorsTimeout.test.ts
+++ b/tests/agent/tools/toolExecutorsTimeout.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@renderer/services/electronAPI', () => ({
+  api: {
+    file: {
+      read: vi.fn(),
+      readRichContent: vi.fn(),
+      readImageAnalysis: vi.fn(),
+      write: vi.fn(),
+      readDir: vi.fn(),
+    },
+    http: {
+      webSearch: vi.fn(() => new Promise(() => {})),
+      readUrl: vi.fn(),
+    },
+    index: {
+      parseCallGraph: vi.fn(async () => []),
+    },
+  },
+}))
+
+vi.mock('@renderer/agent/services/imageReadService', () => ({
+  analyzeImageSource: vi.fn(),
+  getReadImageUnavailableMessage: vi.fn(() => 'Error: read_image requires a configured multimodal model.'),
+  getReadRichContentOptions: vi.fn(() => ({})),
+}))
+
+vi.mock('@renderer/services/lspService', () => ({
+  waitForDiagnostics: vi.fn(),
+  isLanguageSupported: vi.fn(() => false),
+  getLanguageId: vi.fn(() => 'typescript'),
+  didOpenDocument: vi.fn(),
+}))
+
+vi.mock('@renderer/agent/utils/AgentConfig', () => ({
+  getAgentConfig: vi.fn(() => ({
+    maxSingleFileChars: 10000,
+    toolTimeoutMs: 20,
+    ignoredDirectories: [],
+  })),
+}))
+
+vi.mock('@renderer/agent/services/fileCacheService', () => ({
+  fileCacheService: {
+    markFileAsRead: vi.fn(),
+  },
+}))
+
+vi.mock('@renderer/agent/services/lintService', () => ({
+  lintService: {},
+}))
+
+vi.mock('@renderer/agent/services/memoryService', () => ({
+  memoryService: {},
+  normalizeMemoryContentInput: vi.fn(),
+}))
+
+vi.mock('@/renderer/store', () => ({
+  useStore: {
+    getState: vi.fn(() => ({
+      setTerminalVisible: vi.fn(),
+    })),
+  },
+}))
+
+vi.mock('@renderer/agent/services/composerService', () => ({
+  composerService: {
+    ensureSession: vi.fn(),
+    addChange: vi.fn(),
+  },
+}))
+
+vi.mock('@renderer/agent/store/agentStoreBridge', () => ({
+  agentStorePlanBridge: {},
+  agentStoreTodoBridge: {},
+}))
+
+vi.mock('@renderer/agent/utils/fileChangeUtils', () => ({
+  buildFileChangeDescriptor: vi.fn(() => ({})),
+}))
+
+vi.mock('@renderer/agent/tools/commandRuntime', () => ({
+  isLongRunningCommand: vi.fn(() => false),
+}))
+
+vi.mock('@renderer/services/internalWriteTracker', () => ({
+  internalWriteTracker: {
+    mark: vi.fn(),
+  },
+}))
+
+vi.mock('@renderer/agent/services/skillService', () => ({
+  skillService: {},
+}))
+
+vi.mock('@renderer/agent/utils/agentText', () => ({
+  getAgentLanguage: vi.fn(() => 'en'),
+  pickLocalizedText: vi.fn((zh: string, en: string) => en),
+  translateAgentText: vi.fn((key: string) => key),
+}))
+
+vi.mock('@renderer/agent/tools/fileWriteStrategy', () => ({
+  guardWriteFile: vi.fn(),
+}))
+
+vi.mock('@utils/Logger', () => ({
+  logger: {
+    agent: {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  },
+}))
+
+import { toolExecutors } from '@renderer/agent/tools/executors'
+
+describe('toolExecutors timeout wrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('uses the configured agent tool timeout for the wrapper', async () => {
+    const resultPromise = toolExecutors.web_search({ query: 'timeout test' }, {} as any)
+    await vi.advanceTimersByTimeAsync(20)
+    const result = await resultPromise
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Tool execution error')
+  })
+})


### PR DESCRIPTION
## 变更说明

- 将 agent 工具外层包装的超时统一改为读取 `toolTimeoutMs`，不再对部分工具写死 60s/120s。
- 让 MCP 工具调用也透传同一份 `toolTimeoutMs`，避免设置项只影响部分路径。
- 新增测试覆盖内建工具超时包装和 MCP 工具超时透传。

## 验证

- `pnpm vitest run tests/agent/tools/mcpToolProvider.test.ts tests/agent/tools/toolExecutorsTimeout.test.ts tests/services/mcpService.test.ts`
