### PR TITLE
Potential fix for code scanning alert no. 26: Uncontrolled command line

### DIFF
--- a/src/main/lsp/installer.ts
+++ b/src/main/lsp/installer.ts
@@ -9,7 +9,7 @@
  */
 
 import { app } from 'electron'
-import { spawn, execSync } from 'child_process'
+import { spawn, spawnSync } from 'child_process'
 import * as path from 'path'
 import * as fs from 'fs'
 import { logger } from '@shared/utils/Logger'
@@ -385,12 +385,21 @@ async function extractTarXz(archivePath: string, destDir: string): Promise<boole
       // Windows: 使用 tar 命令（Windows 10 1803+ 内置）
       logger.lsp.debug('[LSP Installer] Using Windows tar command')
       try {
-        const output = execSync(`tar -xf "${archivePath}"`, {
+        const result = spawnSync('tar', ['-xf', archivePath], {
           cwd: destDir,
           stdio: 'pipe',
           encoding: 'utf-8',
         })
-        logger.lsp.debug(`[LSP Installer] tar output: ${output}`)
+        if (result.error || result.status !== 0) {
+          logger.lsp.error('[LSP Installer] tar command failed on Windows', {
+            status: result.status,
+            error: result.error?.message,
+            stderr: result.stderr,
+          })
+          logger.lsp.warn('[LSP Installer] Please ensure tar is available (Windows 10 1803+ or install 7-Zip)')
+          return false
+        }
+        logger.lsp.debug(`[LSP Installer] tar output: ${result.stdout || ''}`)
         logger.lsp.info('[LSP Installer] tar.xz extracted successfully (Windows)')
         return true
       } catch (err) {
@@ -410,12 +419,20 @@ async function extractTarXz(archivePath: string, destDir: string): Promise<boole
       }
 
       try {
-        const output = execSync(`tar -xf "${archivePath}"`, {
+        const result = spawnSync('tar', ['-xf', archivePath], {
           cwd: destDir,
           stdio: 'pipe',
           encoding: 'utf-8',
         })
-        logger.lsp.debug(`[LSP Installer] tar output: ${output}`)
+        if (result.error || result.status !== 0) {
+          logger.lsp.error('[LSP Installer] tar command failed on Unix', {
+            status: result.status,
+            error: result.error?.message,
+            stderr: result.stderr,
+          })
+          return false
+        }
+        logger.lsp.debug(`[LSP Installer] tar output: ${result.stdout || ''}`)
         logger.lsp.info('[LSP Installer] tar.xz extracted successfully (Unix)')
         return true
       } catch (err) {


### PR DESCRIPTION
Potential fix for [https://github.com/ad-naan/Adnify/security/code-scanning/26](https://github.com/ad-naan/Adnify/security/code-scanning/26)

Best fix: stop using `execSync` with an interpolated command string, and invoke `tar` without a shell using argument arrays (e.g., `spawnSync`/`execFileSync`). This preserves behavior while removing shell command injection risk from untrusted path content.

In `src/main/lsp/installer.ts`:
- Update child_process import to include `spawnSync`.
- In `extractTarXz`, replace both `execSync(\`tar -xf "${archivePath}"\`, ...)` blocks (Windows and Unix branches) with `spawnSync('tar', ['-xf', archivePath], { ... })`.
- Check `result.status` / `result.error`, log stdout/stderr similarly, and keep return semantics unchanged.

This is the minimal, safest change that does not alter existing functionality (still using system `tar`, same cwd, same extraction flags), but removes shell parsing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
