### PR TITLE
refactor: restructure settings sidebar with grouped nav and editor sub-tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1403,6 +1403,9 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@lancedb/lancedb/node_modules/@lancedb/lancedb-darwin-x64": {
+      "optional": true
+    },
     "node_modules/@lancedb/lancedb/node_modules/@lancedb/lancedb-win32-x64-msvc": {
       "version": "0.23.0",
       "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.23.0.tgz",

--- a/src/renderer/components/agent/ChatMessage.tsx
+++ b/src/renderer/components/agent/ChatMessage.tsx
@@ -374,38 +374,17 @@ MessageMetaGroup.displayName = 'MessageMetaGroup'
 function buildProcessSummaryText(summary: AssistantProcessSummary, language: 'zh' | 'en'): string {
   const items: string[] = []
 
+  // 固定开头为 Work
+  items.push(language === 'zh' ? '工作' : 'Work')
+
+  // 工具数量：Tool × N
   if (summary.toolCallCount > 0) {
-    items.push(language === 'zh'
-      ? `${summary.toolCallCount} 个工具`
-      : `${summary.toolCallCount} tool${summary.toolCallCount > 1 ? 's' : ''}`)
+    items.push(`工具·${summary.toolCallCount}`)
   }
 
+  // 有思考时才追加
   if (summary.hasReasoning) {
     items.push(language === 'zh' ? '思考' : 'Thinking')
-  }
-
-  if (summary.hasSearch) {
-    items.push(language === 'zh' ? '搜索' : 'Search')
-  }
-
-  if (summary.hasContext) {
-    items.push(language === 'zh' ? '上下文' : 'Context')
-  }
-
-  if (summary.hasSources) {
-    items.push(language === 'zh' ? '来源' : 'Sources')
-  }
-
-  if (summary.hasLintCheck) {
-    items.push(language === 'zh' ? '检查' : 'Checks')
-  }
-
-  if (summary.hasSystemAlert) {
-    items.push(language === 'zh' ? '提示' : 'Alerts')
-  }
-
-  if (summary.hasProcessText) {
-    items.push(language === 'zh' ? '说明' : 'Notes')
   }
 
   return items.join(' · ')

--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -30,7 +30,6 @@ import { t } from '@renderer/i18n'
 import { Button } from '../ui'
 import ModelSelector from './ModelSelector'
 import ModeSelector from './ModeSelector'
-import { KaomojiPet } from './KaomojiPet'
 
 import { ContextItem, FileContext } from '@/renderer/agent/types'
 
@@ -392,22 +391,6 @@ const ChatInput = memo(function ChatInput({
               )}
             </div>
           </div>
-        </div>
-      </div>
-
-      {/* Bottom Footer Area */}
-      <div className="mt-3 mb-1 flex min-h-9 items-center justify-between gap-4 px-4 pb-1">
-
-        {/* Left Side: Dynamic Pet */}
-        <div className="hidden min-w-0 flex-1 sm:flex items-center">
-          <KaomojiPet language={language} isStreaming={isStreaming} hasInput={isSendable} />
-        </div>
-
-        {/* Right Side: Key Shortcuts */}
-        <div className="hidden sm:flex items-center gap-2 text-[10px] text-text-muted/45 font-medium tracking-wide whitespace-nowrap overflow-hidden shrink-0">
-          <span>{isStreaming ? 'Enter Queue' : 'Enter Send'}</span>
-          <span className="w-1 h-1 rounded-full bg-current opacity-30" />
-          <span>Shift Enter New Line</span>
         </div>
       </div>
     </div>

--- a/src/renderer/components/chat/EmptyChatSuggestions.tsx
+++ b/src/renderer/components/chat/EmptyChatSuggestions.tsx
@@ -1,15 +1,13 @@
 import { motion } from 'framer-motion'
-import { Sparkles, Code, FileText, Bug, ArrowRight, GitBranch, FolderOpen, FileCode, Clock, RefreshCw, Zap, Box, AlertCircle, Layers, Wand2 } from 'lucide-react'
+import { GitBranch, FolderOpen, FileCode, Clock, RefreshCw } from 'lucide-react'
 import { useStore } from '@store'
 import { getFileName } from '@shared/utils/pathUtils'
-import { ScrollShadow } from '../ui/ScrollShadow'
-import { OtterAsset } from '@/renderer/components/brand/OtterAsset'
 
 interface EmptyChatSuggestionsProps {
     onSelectSuggestion: (text: string) => void
 }
 
-export default function EmptyChatSuggestions({ onSelectSuggestion }: EmptyChatSuggestionsProps) {
+export default function EmptyChatSuggestions({ onSelectSuggestion: _onSelectSuggestion }: EmptyChatSuggestionsProps) {
     const language = useStore(s => s.language)
     const workspacePath = useStore(s => s.workspacePath)
     const gitStatus = useStore(s => s.gitStatus)
@@ -30,23 +28,8 @@ export default function EmptyChatSuggestions({ onSelectSuggestion }: EmptyChatSu
                 transition={{ duration: 0.4 }}
                 className="flex flex-col h-full"
             >
-                {/* 1. Header Card */}
-                <div className="flex items-center gap-4 bg-gradient-to-r from-[rgb(var(--accent)/0.08)] to-[rgb(var(--accent)/0.02)] p-5 rounded-2xl mb-8 border border-[rgb(var(--accent)/0.1)]">
-                    <OtterAsset asset="working" alt="AI" className="h-16 w-16 object-contain drop-shadow-md" />
-                    <div>
-                        <h2 className="text-[15px] font-semibold text-[rgb(var(--text-primary))] mb-1.5 tracking-tight">
-                            {language === 'zh' ? '今天准备推进哪一块？' : 'What are we pushing forward today?'}
-                        </h2>
-                        <p className="text-[12px] text-[rgb(var(--text-secondary))] leading-relaxed max-w-[240px]">
-                            {language === 'zh'
-                                ? '我已就绪，随时帮你拆解任务、生成代码、定位问题，让推进更高效。'
-                                : 'I am ready to help you break down tasks, generate code, and locate issues to make your work more efficient.'}
-                        </p>
-                    </div>
-                </div>
-
-                {/* 2. Project Insights */}
-                <div className="mb-8">
+                {/* Project Insights */}
+                <div>
                     <div className="flex items-center justify-between mb-3 px-1">
                         <h3 className="text-[13px] font-bold text-[rgb(var(--text-primary))]">{language === 'zh' ? '项目洞察' : 'Project Insights'}</h3>
                         <button className="flex items-center gap-1.5 text-[11px] text-[rgb(var(--text-muted))] hover:text-[rgb(var(--text-primary))] transition-colors">
@@ -101,81 +84,6 @@ export default function EmptyChatSuggestions({ onSelectSuggestion }: EmptyChatSu
                             </div>
                         </div>
                     </div>
-                </div>
-
-                {/* 3. Command Center */}
-                <div className="mb-8">
-                    <div className="flex items-center justify-between mb-3 px-1">
-                        <h3 className="text-[13px] font-bold text-[rgb(var(--text-primary))]">{language === 'zh' ? '命令中心' : 'Command Center'}</h3>
-                        <div className="text-[11px] text-[rgb(var(--text-muted))] flex items-center gap-1">
-                            <Zap className="w-3 h-3" />
-                            {language === 'zh' ? '快捷执行' : 'Quick Execute'}
-                        </div>
-                    </div>
-                    <div className="grid grid-cols-4 gap-2">
-                        <button onClick={() => onSelectSuggestion('/explain')} className="flex flex-col items-center justify-center py-3 px-1 bg-[rgb(var(--surface)/0.6)] border border-[rgb(var(--border)/0.5)] rounded-xl hover:bg-[rgb(var(--accent)/0.1)] hover:border-[rgb(var(--accent)/0.3)] transition-colors group">
-                            <div className="text-[rgb(var(--accent))] text-[12px] font-bold mb-1 flex items-center gap-1"><Sparkles className="w-3 h-3" /> /explain</div>
-                            <div className="text-[10px] text-[rgb(var(--text-muted))] group-hover:text-[rgb(var(--text-secondary))]">{language === 'zh' ? '解释这段代码' : 'Explain code'}</div>
-                        </button>
-                        <button onClick={() => onSelectSuggestion('/generate')} className="flex flex-col items-center justify-center py-3 px-1 bg-[rgb(var(--surface)/0.6)] border border-[rgb(var(--border)/0.5)] rounded-xl hover:bg-[rgb(var(--accent)/0.1)] hover:border-[rgb(var(--accent)/0.3)] transition-colors group">
-                            <div className="text-[rgb(var(--accent))] text-[12px] font-bold mb-1 flex items-center gap-1"><Code className="w-3 h-3" /> /generate</div>
-                            <div className="text-[10px] text-[rgb(var(--text-muted))] group-hover:text-[rgb(var(--text-secondary))]">{language === 'zh' ? '生成代码' : 'Generate'}</div>
-                        </button>
-                        <button onClick={() => onSelectSuggestion('/refactor')} className="flex flex-col items-center justify-center py-3 px-1 bg-[rgb(var(--surface)/0.6)] border border-[rgb(var(--border)/0.5)] rounded-xl hover:bg-emerald-500/10 hover:border-emerald-500/30 transition-colors group">
-                            <div className="text-emerald-500 text-[12px] font-bold mb-1 flex items-center gap-1"><Wand2 className="w-3 h-3" /> /refactor</div>
-                            <div className="text-[10px] text-[rgb(var(--text-muted))] group-hover:text-[rgb(var(--text-secondary))]">{language === 'zh' ? '重构代码' : 'Refactor'}</div>
-                        </button>
-                        <button onClick={() => onSelectSuggestion('/fix')} className="flex flex-col items-center justify-center py-3 px-1 bg-[rgb(var(--surface)/0.6)] border border-[rgb(var(--border)/0.5)] rounded-xl hover:bg-orange-500/10 hover:border-orange-500/30 transition-colors group">
-                            <div className="text-orange-500 text-[12px] font-bold mb-1 flex items-center gap-1"><Bug className="w-3 h-3" /> /fix</div>
-                            <div className="text-[10px] text-[rgb(var(--text-muted))] group-hover:text-[rgb(var(--text-secondary))]">{language === 'zh' ? '修复问题' : 'Fix bugs'}</div>
-                        </button>
-                    </div>
-                </div>
-
-                {/* 4. Start From Here */}
-                <div className="flex flex-col flex-1 min-h-0">
-                    <h3 className="text-[13px] font-bold text-[rgb(var(--text-primary))] mb-3 px-1 shrink-0">{language === 'zh' ? '从这里开始' : 'Start from here'}</h3>
-                    <ScrollShadow className="flex-1 min-h-0" maxHeight="100%">
-                        <div className="flex flex-col gap-2 pb-6 px-1">
-                            {[
-                            {
-                                icon: <Layers className="w-4 h-4 text-[rgb(var(--accent))]" />, iconBg: 'bg-[rgb(var(--accent)/0.1)]',
-                                title: language === 'zh' ? '梳理当前项目' : 'Analyze current project',
-                                desc: language === 'zh' ? '分析结构与依赖，快速掌握项目全貌' : 'Analyze structure and dependencies to master the project',
-                                prompt: language === 'zh' ? '请帮我梳理当前项目，分析目录结构与核心依赖，让我快速掌握项目全貌。' : 'Please analyze the current project structure and dependencies.'
-                            },
-                            {
-                                icon: <Box className="w-4 h-4 text-emerald-500" />, iconBg: 'bg-emerald-500/10',
-                                title: language === 'zh' ? '为这个模块生成方案' : 'Generate module plan',
-                                desc: language === 'zh' ? '基于当前目录，生成实施方案与模块设计' : 'Generate implementation plan based on current directory',
-                                prompt: language === 'zh' ? '请基于当前激活的目录或文件，为这个模块生成一份实施方案与模块设计。' : 'Please generate an implementation plan and module design.'
-                            },
-                            {
-                                icon: <FileText className="w-4 h-4 text-emerald-500" />, iconBg: 'bg-emerald-500/10',
-                                title: language === 'zh' ? '为选中文件补充注释' : 'Add comments to file',
-                                desc: language === 'zh' ? '自动生成注释与类型说明，提升可读性' : 'Auto-generate comments to improve readability',
-                                prompt: language === 'zh' ? '请为我当前选中的文件补充完整的注释与类型说明，提升代码可读性。' : 'Please add comprehensive comments and type declarations to the active file.'
-                            },
-                            {
-                                icon: <AlertCircle className="w-4 h-4 text-orange-500" />, iconBg: 'bg-orange-500/10',
-                                title: language === 'zh' ? '定位隐藏问题' : 'Find hidden issues',
-                                desc: language === 'zh' ? '扫描潜在风险与缺陷，给出修复建议' : 'Scan for potential risks and suggest fixes',
-                                prompt: language === 'zh' ? '请帮我扫描当前项目或激活文件的潜在风险、性能缺陷与安全隐患，并给出修复建议。' : 'Please scan the current project for potential bugs, security risks, and provide fixes.'
-                            }
-                        ].map((item, idx) => (
-                            <button key={idx} onClick={() => onSelectSuggestion(item.prompt)} className="flex items-center gap-4 p-3.5 rounded-xl border border-transparent bg-[rgb(var(--surface)/0.3)] hover:bg-[rgb(var(--surface))] hover:border-[rgb(var(--border)/0.6)] transition-all text-left group">
-                                <div className={`p-2.5 rounded-xl ${item.iconBg}`}>
-                                    {item.icon}
-                                </div>
-                                <div className="flex-1 min-w-0">
-                                    <div className="text-[13px] font-semibold text-[rgb(var(--text-primary))] mb-0.5">{item.title}</div>
-                                    <div className="text-[11px] text-[rgb(var(--text-muted))] truncate">{item.desc}</div>
-                                </div>
-                                <ArrowRight className="w-4 h-4 text-[rgb(var(--text-muted))] opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all" />
-                            </button>
-                        ))}
-                        </div>
-                    </ScrollShadow>
                 </div>
             </motion.div>
         </div>

--- a/src/renderer/components/layout/ActivityBar.tsx
+++ b/src/renderer/components/layout/ActivityBar.tsx
@@ -1,4 +1,4 @@
-import { Files, Search, GitBranch, Settings, AlertCircle, ListTree, History, Brain, Terminal } from 'lucide-react'
+import { Files, Search, GitBranch, Settings, AlertCircle, ListTree, Brain, Terminal } from 'lucide-react'
 import { Tooltip } from '../ui/Tooltip'
 import { useStore } from '@store'
 import { useShallow } from 'zustand/react/shallow'
@@ -14,7 +14,6 @@ export default function ActivityBar() {
     { id: 'emotion', icon: Brain, label: language === 'zh' ? '情绪感知' : 'Mood' },
     { id: 'problems', icon: AlertCircle, label: language === 'zh' ? '问题' : 'Problems' },
     { id: 'outline', icon: ListTree, label: language === 'zh' ? '大纲' : 'Outline' },
-    { id: 'history', icon: History, label: language === 'zh' ? '历史' : 'History' },
     { id: 'shell', icon: Terminal, label: 'Shell' },
   ] as const
 

--- a/src/renderer/components/settings/SettingsModal.tsx
+++ b/src/renderer/components/settings/SettingsModal.tsx
@@ -405,20 +405,53 @@ export default function SettingsModal() {
         providers.find(provider => provider.id === localConfig.provider),
         [localConfig.provider, providers])
 
-    const tabs = useMemo(() => [
-        { id: 'provider', label: language === 'zh' ? '模型提供商' : 'Providers', icon: <Cpu className="w-4 h-4" /> },
-        { id: 'editor', label: language === 'zh' ? '编辑器' : 'Editor', icon: <Code className="w-4 h-4" /> },
-        { id: 'snippets', label: language === 'zh' ? '代码片段' : 'Snippets', icon: <FileCode className="w-4 h-4" /> },
-        { id: 'agent', label: language === 'zh' ? '智能体' : 'Agent', icon: <Settings2 className="w-4 h-4" /> },
-        { id: 'rules', label: language === 'zh' ? '规则与记忆' : 'Rules & Memory', icon: <Brain className="w-4 h-4" /> },
-        { id: 'skills', label: 'Skills', icon: <Zap className="w-4 h-4" /> },
-        { id: 'mcp', label: 'MCP', icon: <Plug className="w-4 h-4" /> },
-        { id: 'lsp', label: language === 'zh' ? '语言服务' : 'LSP', icon: <Braces className="w-4 h-4" /> },
-        { id: 'keybindings', label: language === 'zh' ? '快捷键' : 'Keybindings', icon: <Keyboard className="w-4 h-4" /> },
-        { id: 'indexing', label: language === 'zh' ? '代码索引' : 'Indexing', icon: <Database className="w-4 h-4" /> },
-        { id: 'security', label: language === 'zh' ? '安全设置' : 'Security', icon: <Shield className="w-4 h-4" /> },
-        { id: 'system', label: language === 'zh' ? '系统' : 'System', icon: <Monitor className="w-4 h-4" /> },
-    ] as const, [language])
+    // Sidebar groups — provides visual hierarchy
+    type SidebarItem = { id: SettingsTab; label: { zh: string; en: string }; icon: React.ReactNode }
+    type SidebarGroup = { label: { zh: string; en: string }; items: readonly SidebarItem[] }
+
+    const sidebarGroups = useMemo<readonly SidebarGroup[]>(() => [
+        {
+            label: { zh: 'AI', en: 'AI' },
+            items: [
+                { id: 'provider', label: { zh: '模型提供商', en: 'Providers' }, icon: <Cpu className="w-4 h-4" /> },
+                { id: 'agent', label: { zh: '智能体', en: 'Agent' }, icon: <Settings2 className="w-4 h-4" /> },
+                { id: 'mcp', label: { zh: 'MCP', en: 'MCP' }, icon: <Plug className="w-4 h-4" /> },
+                { id: 'skills', label: { zh: 'Skills', en: 'Skills' }, icon: <Zap className="w-4 h-4" /> },
+            ],
+        },
+        {
+            label: { zh: '编辑器', en: 'Editor' },
+            items: [
+                { id: 'editor', label: { zh: '编辑器', en: 'Editor' }, icon: <Code className="w-4 h-4" /> },
+                { id: 'snippets', label: { zh: '代码片段', en: 'Snippets' }, icon: <FileCode className="w-4 h-4" /> },
+                { id: 'lsp', label: { zh: '语言服务', en: 'LSP' }, icon: <Braces className="w-4 h-4" /> },
+                { id: 'keybindings', label: { zh: '快捷键', en: 'Keybindings' }, icon: <Keyboard className="w-4 h-4" /> },
+            ],
+        },
+        {
+            label: { zh: '项目', en: 'Project' },
+            items: [
+                { id: 'rules', label: { zh: '规则与记忆', en: 'Rules & Memory' }, icon: <Brain className="w-4 h-4" /> },
+                { id: 'indexing', label: { zh: '代码索引', en: 'Indexing' }, icon: <Database className="w-4 h-4" /> },
+            ],
+        },
+        {
+            label: { zh: '系统', en: 'System' },
+            items: [
+                { id: 'security', label: { zh: '安全设置', en: 'Security' }, icon: <Shield className="w-4 h-4" /> },
+                { id: 'system', label: { zh: '系统', en: 'System' }, icon: <Monitor className="w-4 h-4" /> },
+            ],
+        },
+    ] as const, [])
+
+    // Flat lookup for the active page title
+    const activeTabLabel = useMemo(() => {
+        for (const group of sidebarGroups) {
+            const found = (group.items as SidebarItem[]).find(item => item.id === activeTab)
+            if (found) return language === 'zh' ? found.label.zh : found.label.en
+        }
+        return ''
+    }, [activeTab, language])
 
     const renderActiveTab = () => {
         switch (activeTab) {
@@ -515,18 +548,33 @@ export default function SettingsModal() {
                         </h2>
                     </div>
 
-                    <nav className="flex-1 p-4 space-y-1 overflow-y-auto no-scrollbar">
-                        {tabs.map(tab => (
-                            <button
-                                key={tab.id}
-                                onClick={() => setActiveTab(tab.id)}
-                                className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-200 group ${activeTab === tab.id ? 'bg-accent/10 text-text-primary border border-accent/20' : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary border border-transparent'}`}
-                            >
-                                <span className={`transition-colors duration-200 ${activeTab === tab.id ? 'text-accent' : 'text-text-muted group-hover:text-text-primary'}`}>
-                                    {tab.icon}
-                                </span>
-                                <span>{tab.label}</span>
-                            </button>
+                    <nav className="flex-1 px-3 py-2 overflow-y-auto no-scrollbar space-y-4">
+                        {sidebarGroups.map((group, gi) => (
+                            <div key={gi}>
+                                <div className="mx-4 mt-2 mb-1 text-[10px] font-bold text-text-muted uppercase tracking-widest">
+                                    {language === 'zh' ? group.label.zh : group.label.en}
+                                </div>
+                                <div className="space-y-0.5">
+                                    {(group.items as SidebarItem[]).map(tab => (
+                                        <button
+                                            key={tab.id}
+                                            onClick={() => setActiveTab(tab.id)}
+                                            className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-200 group ${
+                                                activeTab === tab.id
+                                                    ? 'bg-accent/10 text-text-primary border border-accent/20'
+                                                    : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary border border-transparent'
+                                            }`}
+                                        >
+                                            <span className={`transition-colors duration-200 ${
+                                                activeTab === tab.id ? 'text-accent' : 'text-text-muted group-hover:text-text-primary'
+                                            }`}>
+                                                {tab.icon}
+                                            </span>
+                                            <span>{language === 'zh' ? tab.label.zh : tab.label.en}</span>
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
                         ))}
                     </nav>
 
@@ -548,7 +596,7 @@ export default function SettingsModal() {
                     <div className="settings-scroll-region flex-1 overflow-y-auto px-8 py-8 custom-scrollbar pb-28">
                         <div className="mb-6 pb-5 border-b border-border/40">
                             <h3 className="text-2xl font-semibold text-text-primary tracking-tight">
-                                {tabs.find(tab => tab.id === activeTab)?.label}
+                                {activeTabLabel}
                             </h3>
                             <p className="text-sm text-text-muted mt-1.5 opacity-80">
                                 {t('settings.managePreferences', language as Language)}

--- a/src/renderer/components/settings/tabs/AgentSettings.tsx
+++ b/src/renderer/components/settings/tabs/AgentSettings.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react'
 import { getPromptTemplates } from '@renderer/agent/prompts/promptTemplates'
 import { DEFAULT_AGENT_CONFIG } from '@shared/config/agentConfig'
 import { Button, Input, Select, Switch } from '@components/ui'
-import { AgentSettingsProps } from '../types'
+import { AgentSettingsProps, SETTINGS_PAGE, SETTINGS_SECTION, SETTINGS_LABEL } from '../types'
 import { PromptPreviewModal } from './PromptPreviewModal'
 import { Bot, FileText, Zap, BrainCircuit, AlertOctagon, Terminal, Search, Eye, EyeOff, RefreshCw } from 'lucide-react'
 
@@ -47,12 +47,12 @@ export function AgentSettings({
     const t = (zh: string, en: string) => language === 'zh' ? zh : en
 
     return (
-        <div className="space-y-8 animate-fade-in pb-10">
+        <div className={SETTINGS_PAGE}>
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 {/* Left Column */}
                 <div className="space-y-6">
                     {/* 自动化权限 */}
-                    <section className="p-5 bg-surface/30 rounded-xl border border-border space-y-4">
+                    <section className={SETTINGS_SECTION}>
                         <div className="flex items-center gap-2 mb-1">
                             <Zap className="w-4 h-4 text-accent" />
                             <h5 className="text-sm font-medium text-text-primary">{t('自动化权限', 'Automation Permissions')}</h5>
@@ -86,14 +86,14 @@ export function AgentSettings({
                     </section>
 
                     {/* Prompt 模板 */}
-                    <section className="p-5 bg-surface/30 rounded-xl border border-border space-y-4">
+                    <section className={SETTINGS_SECTION}>
                         <div className="flex items-center gap-2 mb-1">
                             <Bot className="w-4 h-4 text-accent" />
                             <h5 className="text-sm font-medium text-text-primary">{t('Prompt 模板', 'Prompt Template')}</h5>
                         </div>
                         <div className="space-y-3">
                             <div className="space-y-1.5">
-                                <label className="text-xs font-medium text-text-secondary">{t('选择模板', 'Select Template')}</label>
+                                <label className={SETTINGS_LABEL}>{t('选择模板', 'Select Template')}</label>
                                 <Select
                                     value={promptTemplateId}
                                     onChange={(value) => setPromptTemplateId(value)}
@@ -137,7 +137,7 @@ export function AgentSettings({
                     </section>
 
                     {/* 自定义系统指令 */}
-                    <section className="p-5 bg-surface/30 rounded-xl border border-border space-y-4">
+                    <section className={SETTINGS_SECTION}>
                         <div className="flex items-center gap-2 mb-1">
                             <Terminal className="w-4 h-4 text-accent" />
                             <h5 className="text-sm font-medium text-text-primary">{t('自定义系统指令', 'Custom Instructions')}</h5>
@@ -154,7 +154,7 @@ export function AgentSettings({
                     </section>
 
                     {/* 网络搜索配置 */}
-                    <section className="p-5 bg-surface/30 rounded-xl border border-border space-y-4">
+                    <section className={SETTINGS_SECTION}>
                         <div className="flex items-center gap-2 mb-1">
                             <Search className="w-4 h-4 text-accent" />
                             <h5 className="text-sm font-medium text-text-primary">{t('网络搜索', 'Web Search')}</h5>
@@ -167,7 +167,7 @@ export function AgentSettings({
                         </p>
                         <div className="space-y-3">
                             <div className="space-y-1.5">
-                                <label className="text-xs font-medium text-text-secondary">Google API Key</label>
+                                <label className={SETTINGS_LABEL}>Google API Key</label>
                                 <div className="relative">
                                     <Input
                                         type={showGoogleApiKey ? 'text' : 'password'}
@@ -186,7 +186,7 @@ export function AgentSettings({
                                 </div>
                             </div>
                             <div className="space-y-1.5">
-                                <label className="text-xs font-medium text-text-secondary">{t('搜索引擎 ID (CX)', 'Search Engine ID (CX)')}</label>
+                                <label className={SETTINGS_LABEL}>{t('搜索引擎 ID (CX)', 'Search Engine ID (CX)')}</label>
                                 <Input
                                     type="text"
                                     value={webSearchConfig.googleCx || ''}
@@ -211,14 +211,14 @@ export function AgentSettings({
                 {/* Right Column */}
                 <div className="space-y-6">
                     {/* 基础配置 */}
-                    <section className="p-5 bg-surface/30 rounded-xl border border-border space-y-4">
+                    <section className={SETTINGS_SECTION}>
                         <div className="flex items-center gap-2 mb-1">
                             <BrainCircuit className="w-4 h-4 text-accent" />
                             <h5 className="text-sm font-medium text-text-primary">{t('基础配置', 'Basic Configuration')}</h5>
                         </div>
                         <div className="grid grid-cols-2 gap-4">
                             <div className="space-y-1.5">
-                                <label className="text-xs font-medium text-text-secondary">{t('最大循环', 'Max Loops')}</label>
+                                <label className={SETTINGS_LABEL}>{t('最大循环', 'Max Loops')}</label>
                                 <Input
                                     type="number"
                                     value={agentConfig.maxToolLoops}
@@ -229,7 +229,7 @@ export function AgentSettings({
                                 />
                             </div>
                             <div className="space-y-1.5">
-                                <label className="text-xs font-medium text-text-secondary">{t('最大历史消息', 'Max History')}</label>
+                                <label className={SETTINGS_LABEL}>{t('最大历史消息', 'Max History')}</label>
                                 <Input
                                     type="number"
                                     value={agentConfig.maxHistoryMessages}
@@ -243,7 +243,7 @@ export function AgentSettings({
                     </section>
 
                     {/* 上下文限制 */}
-                    <section className="p-5 bg-surface/30 rounded-xl border border-border space-y-4">
+                    <section className={SETTINGS_SECTION}>
                         <div className="flex items-center gap-2 mb-1">
                             <FileText className="w-4 h-4 text-accent" />
                             <h5 className="text-sm font-medium text-text-primary">{t('上下文限制', 'Context Limits')}</h5>
@@ -251,7 +251,7 @@ export function AgentSettings({
 
                         <div className="grid grid-cols-2 gap-4">
                             <div className="space-y-1.5">
-                                <label className="text-xs font-medium text-text-secondary">{t('工具结果限制', 'Tool Result Limit')}</label>
+                                <label className={SETTINGS_LABEL}>{t('工具结果限制', 'Tool Result Limit')}</label>
                                 <Input
                                     type="number"
                                     value={agentConfig.maxToolResultChars}
@@ -261,7 +261,7 @@ export function AgentSettings({
                                 />
                             </div>
                             <div className="space-y-1.5">
-                                <label className="text-xs font-medium text-text-secondary">{t('上下文 Token 限制', 'Context Token Limit')}</label>
+                                <label className={SETTINGS_LABEL}>{t('上下文 Token 限制', 'Context Token Limit')}</label>
                                 <Input
                                     type="number"
                                     value={agentConfig.maxContextTokens ?? 128000}
@@ -271,7 +271,7 @@ export function AgentSettings({
                                 />
                             </div>
                             <div className="space-y-1.5">
-                                <label className="text-xs font-medium text-text-secondary">{t('单文件内容限制', 'File Content Limit')}</label>
+                                <label className={SETTINGS_LABEL}>{t('单文件内容限制', 'File Content Limit')}</label>
                                 <Input
                                     type="number"
                                     value={agentConfig.maxFileContentChars ?? 15000}
@@ -281,7 +281,7 @@ export function AgentSettings({
                                 />
                             </div>
                             <div className="space-y-1.5">
-                                <label className="text-xs font-medium text-text-secondary">{t('最大文件数', 'Max Files')}</label>
+                                <label className={SETTINGS_LABEL}>{t('最大文件数', 'Max Files')}</label>
                                 <Input
                                     type="number"
                                     value={agentConfig.maxContextFiles ?? 6}
@@ -292,7 +292,7 @@ export function AgentSettings({
                                 />
                             </div>
                             <div className="space-y-1.5">
-                                <label className="text-xs font-medium text-text-secondary">{t('语义搜索结果数', 'Semantic Results')}</label>
+                                <label className={SETTINGS_LABEL}>{t('语义搜索结果数', 'Semantic Results')}</label>
                                 <Input
                                     type="number"
                                     value={agentConfig.maxSemanticResults ?? 5}
@@ -303,7 +303,7 @@ export function AgentSettings({
                                 />
                             </div>
                             <div className="space-y-1.5">
-                                <label className="text-xs font-medium text-text-secondary">{t('终端输出限制', 'Terminal Limit')}</label>
+                                <label className={SETTINGS_LABEL}>{t('终端输出限制', 'Terminal Limit')}</label>
                                 <Input
                                     type="number"
                                     value={agentConfig.maxTerminalChars ?? 3000}
@@ -330,7 +330,7 @@ export function AgentSettings({
                                 {/* 重试 & 超时 */}
                                 <div className="grid grid-cols-2 gap-4">
                                     <div className="space-y-1.5">
-                                        <label className="text-xs font-medium text-text-secondary">{t('最大重试', 'Max Retries')}</label>
+                                        <label className={SETTINGS_LABEL}>{t('最大重试', 'Max Retries')}</label>
                                         <Input
                                             type="number"
                                             value={agentConfig.maxRetries ?? 3}
@@ -341,7 +341,7 @@ export function AgentSettings({
                                         />
                                     </div>
                                     <div className="space-y-1.5">
-                                        <label className="text-xs font-medium text-text-secondary">{t('重试延迟 (ms)', 'Retry Delay')}</label>
+                                        <label className={SETTINGS_LABEL}>{t('重试延迟 (ms)', 'Retry Delay')}</label>
                                         <Input
                                             type="number"
                                             value={agentConfig.retryDelayMs ?? 1000}
@@ -351,7 +351,7 @@ export function AgentSettings({
                                         />
                                     </div>
                                     <div className="space-y-1.5">
-                                        <label className="text-xs font-medium text-text-secondary">{t('工具超时 (ms)', 'Tool Timeout')}</label>
+                                        <label className={SETTINGS_LABEL}>{t('工具超时 (ms)', 'Tool Timeout')}</label>
                                         <Input
                                             type="number"
                                             value={agentConfig.toolTimeoutMs ?? 60000}
@@ -363,7 +363,7 @@ export function AgentSettings({
                                 </div>
 
                                 {/* 上下文压缩 */}
-                                <div className="p-4 bg-background/30 rounded-xl border border-border/50 space-y-4">
+                                <div className={SETTINGS_SECTION}>
                                     <div className="flex items-center gap-2 mb-1">
                                         <div className="w-1.5 h-1.5 rounded-full bg-accent" />
                                         <label className="text-xs font-bold text-text-primary uppercase tracking-wider">{t('上下文压缩', 'Context Compression')}</label>
@@ -433,7 +433,7 @@ export function AgentSettings({
                                 </div>
 
                                 {/* 循环检测 */}
-                                <div className="p-4 bg-background/30 rounded-xl border border-border/50 space-y-4">
+                                <div className={SETTINGS_SECTION}>
                                     <div className="flex items-center justify-between mb-1">
                                         <div className="flex items-center gap-2">
                                             <div className="w-1.5 h-1.5 rounded-full bg-accent" />
@@ -498,7 +498,7 @@ export function AgentSettings({
                                 </div>
 
                                 {/* 忽略目录 */}
-                                <div className="p-4 bg-background/30 rounded-xl border border-border/50 space-y-3">
+                                <div className={SETTINGS_SECTION}>
                                     <div className="flex items-center justify-between">
                                         <div className="flex items-center gap-2">
                                             <div className="w-1.5 h-1.5 rounded-full bg-accent" />

--- a/src/renderer/components/settings/tabs/EditorSettings.tsx
+++ b/src/renderer/components/settings/tabs/EditorSettings.tsx
@@ -1,14 +1,15 @@
 /**
- * 编辑器设置组件
+ * 编辑器设置组件 — 带二级子导航
  */
 
+import { useState } from 'react'
 import { api } from '@/renderer/services/electronAPI'
 import { Layout, Type, Sparkles, Terminal, Check, Settings2, Zap } from 'lucide-react'
 import { useStore, type ThemeName } from '@store'
 import { useShallow } from 'zustand/react/shallow'
 import { themeManager } from '@/renderer/config/themeConfig'
 import { Input, Select, Switch } from '@components/ui'
-import { EditorSettingsProps } from '../types'
+import { EditorSettingsProps, SETTINGS_SECTION, SETTINGS_LABEL, SETTINGS_INPUT, SETTINGS_PAGE } from '../types'
 import ThemeWorkbenchPreview from '@renderer/components/theme/ThemeWorkbenchPreview'
 
 // 预定义的触发字符选项
@@ -20,16 +21,34 @@ const TRIGGER_CHAR_OPTIONS = [
     { char: '"', label: '"' },
     { char: "'", label: "'" },
     { char: '/', label: '/' },
-    { char: ' ', label: '␣' }, // 空格用特殊符号显示
+    { char: ' ', label: '␣' },
     { char: ':', label: ':' },
     { char: '<', label: '<' },
     { char: '@', label: '@' },
     { char: '#', label: '#' },
 ]
 
+// 子导航定义
+type EditorSubTab = 'theme' | 'typography' | 'features' | 'terminal' | 'ai-completion' | 'performance'
+
+interface SubTabDef {
+    id: EditorSubTab
+    label: { zh: string; en: string }
+}
+
+const SUB_TABS: SubTabDef[] = [
+    { id: 'theme', label: { zh: '外观主题', en: 'Theme' } },
+    { id: 'typography', label: { zh: '排版布局', en: 'Typography' } },
+    { id: 'features', label: { zh: '功能特性', en: 'Features' } },
+    { id: 'terminal', label: { zh: '终端', en: 'Terminal' } },
+    { id: 'ai-completion', label: { zh: 'AI 补全', en: 'AI Completion' } },
+    { id: 'performance', label: { zh: '性能', en: 'Performance' } },
+]
+
 export function EditorSettings({ settings, setSettings, advancedConfig, setAdvancedConfig, language }: EditorSettingsProps) {
     const { currentTheme, setTheme } = useStore(useShallow(s => ({ currentTheme: s.currentTheme, setTheme: s.setTheme })))
     const allThemes = themeManager.getAllThemes().map(t => t.id)
+    const [activeSubTab, setActiveSubTab] = useState<EditorSubTab>('theme')
 
     const handleThemeChange = (themeId: string) => {
         setTheme(themeId as ThemeName)
@@ -45,308 +64,278 @@ export function EditorSettings({ settings, setSettings, advancedConfig, setAdvan
         }
     }
 
-    // 通用 Section 样式类
-    const sectionClass = "p-6 bg-surface/30 backdrop-blur-sm rounded-xl border border-border/50 space-y-5 shadow-sm hover:border-border transition-colors duration-300"
-    const labelClass = "text-xs font-semibold text-text-secondary uppercase tracking-wider ml-1 mb-2 block"
-    const inputClass = "bg-background/50 border-border/50 text-xs rounded-lg focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all"
+    const t = (zh: string, en: string) => language === 'zh' ? zh : en
+
+    const subNav = (
+        <div className="flex gap-1 p-1 bg-surface/30 rounded-xl border border-border/50 mb-6 overflow-x-auto no-scrollbar">
+            {SUB_TABS.map(tab => (
+                <button
+                    key={tab.id}
+                    onClick={() => setActiveSubTab(tab.id)}
+                    className={`px-3 py-1.5 rounded-lg text-xs font-medium whitespace-nowrap transition-all duration-200 ${
+                        activeSubTab === tab.id
+                            ? 'bg-accent/10 text-accent shadow-sm'
+                            : 'text-text-secondary hover:text-text-primary hover:bg-surface/50'
+                    }`}
+                >
+                    {t(tab.label.zh, tab.label.en)}
+                </button>
+            ))}
+        </div>
+    )
 
     return (
-        <div className="space-y-8 animate-fade-in pb-10">
-            {/* Theme Section */}
-            <section>
-                <div className="flex items-center gap-2 mb-5 ml-1">
-                    <div className="p-1.5 rounded-md bg-accent/10">
-                        <Layout className="w-4 h-4 text-accent" />
-                    </div>
-                    <h4 className="text-sm font-bold text-text-primary tracking-tight">
-                        {language === 'zh' ? '外观主题' : 'Appearance Theme'}
-                    </h4>
-                </div>
-                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
-                    {allThemes.map(themeId => {
-                        const theme = themeManager.getThemeById(themeId)!
-                        return (
-                            <button
-                                key={themeId}
-                                onClick={() => handleThemeChange(themeId)}
-                                className={`group relative p-4 rounded-xl border text-left transition-all duration-300 overflow-hidden ${currentTheme === themeId
-                                    ? 'border-accent bg-accent/5 shadow-lg shadow-accent/5 ring-1 ring-accent/20'
-                                    : 'border-border/50 bg-surface/30 hover:border-accent/30 hover:bg-surface/50'
-                                    }`}
-                            >
-                                <ThemeWorkbenchPreview theme={theme} className="mb-4 h-[108px]" />
-                                <span className={`text-sm font-semibold capitalize block truncate transition-colors ${currentTheme === themeId ? 'text-text-primary' : 'text-text-secondary group-hover:text-text-primary'}`}>
-                                    {themeId.replace(/-/g, ' ')}
-                                </span>
-                                {currentTheme === themeId && (
-                                    <div className="absolute top-3 right-3 bg-accent rounded-full p-0.5 shadow-lg shadow-accent/20">
-                                        <Check className="w-3.5 h-3.5 text-white" strokeWidth={3} />
-                                    </div>
-                                )}
-                            </button>
-                        )
-                    })}
-                </div>
-            </section>
+        <div className={SETTINGS_PAGE}>
+            {subNav}
 
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                {/* Left Column */}
+            {/* 外观主题 */}
+            <div className={activeSubTab === 'theme' ? '' : 'hidden'}>
+                <section>
+                    <div className="flex items-center gap-2 mb-5 ml-1">
+                        <div className="p-1.5 rounded-md bg-accent/10">
+                            <Layout className="w-4 h-4 text-accent" />
+                        </div>
+                        <h4 className="text-sm font-bold text-text-primary tracking-tight">
+                            {t('外观主题', 'Appearance Theme')}
+                        </h4>
+                    </div>
+                    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+                        {allThemes.map(themeId => {
+                            const theme = themeManager.getThemeById(themeId)!
+                            return (
+                                <button
+                                    key={themeId}
+                                    onClick={() => handleThemeChange(themeId)}
+                                    className={`group relative p-4 rounded-xl border text-left transition-all duration-300 overflow-hidden ${
+                                        currentTheme === themeId
+                                            ? 'border-accent bg-accent/5 shadow-lg shadow-accent/5 ring-1 ring-accent/20'
+                                            : 'border-border/50 bg-surface/30 hover:border-accent/30 hover:bg-surface/50'
+                                    }`}
+                                >
+                                    <ThemeWorkbenchPreview theme={theme} className="mb-4 h-[108px]" />
+                                    <span className={`text-sm font-semibold capitalize block truncate transition-colors ${
+                                        currentTheme === themeId ? 'text-text-primary' : 'text-text-secondary group-hover:text-text-primary'
+                                    }`}>
+                                        {themeId.replace(/-/g, ' ')}
+                                    </span>
+                                    {currentTheme === themeId && (
+                                        <div className="absolute top-3 right-3 bg-accent rounded-full p-0.5 shadow-lg shadow-accent/20">
+                                            <Check className="w-3.5 h-3.5 text-white" strokeWidth={3} />
+                                        </div>
+                                    )}
+                                </button>
+                            )
+                        })}
+                    </div>
+                </section>
+            </div>
+
+            {/* 排版布局 */}
+            <div className={activeSubTab === 'typography' ? 'grid grid-cols-1 lg:grid-cols-2 gap-6' : 'hidden'}>
                 <div className="space-y-6">
-                    {/* Typography & Layout */}
-                    <section className={sectionClass}>
+                    <section className={SETTINGS_SECTION}>
                         <div className="flex items-center gap-2 mb-1">
                             <Type className="w-4 h-4 text-accent" />
-                            <h5 className="text-sm font-bold text-text-primary">{language === 'zh' ? '排版与布局' : 'Typography & Layout'}</h5>
+                            <h5 className="text-sm font-bold text-text-primary">{t('排版与布局', 'Typography & Layout')}</h5>
                         </div>
-
                         <div className="grid grid-cols-2 gap-5">
                             <div>
-                                <label className={labelClass}>{language === 'zh' ? '字体大小' : 'Font Size'}</label>
-                                <Input
-                                    type="number"
-                                    value={settings.fontSize}
-                                    onChange={(e) => setSettings({ ...settings, fontSize: parseInt(e.target.value) || 14 })}
-                                    min={10}
-                                    max={32}
-                                    className={inputClass}
-                                />
+                                <label className={SETTINGS_LABEL}>{t('字体大小', 'Font Size')}</label>
+                                <Input type="number" value={settings.fontSize} onChange={(e) => setSettings({ ...settings, fontSize: parseInt(e.target.value) || 14 })} min={10} max={32} className={SETTINGS_INPUT} />
                             </div>
                             <div>
-                                <label className={labelClass}>{language === 'zh' ? 'Tab 大小' : 'Tab Size'}</label>
-                                <Select
-                                    value={settings.tabSize.toString()}
-                                    onChange={(value) => setSettings({ ...settings, tabSize: parseInt(value) })}
+                                <label className={SETTINGS_LABEL}>{t('Tab 大小', 'Tab Size')}</label>
+                                <Select value={settings.tabSize.toString()} onChange={(value) => setSettings({ ...settings, tabSize: parseInt(value) })}
                                     options={[{ value: '2', label: '2 Spaces' }, { value: '4', label: '4 Spaces' }, { value: '8', label: '8 Spaces' }]}
-                                    className={`w-full ${inputClass}`}
-                                />
+                                    className={`w-full ${SETTINGS_INPUT}`} />
                             </div>
                             <div>
-                                <label className={labelClass}>{language === 'zh' ? '自动换行' : 'Word Wrap'}</label>
-                                <Select
-                                    value={settings.wordWrap}
-                                    onChange={(value) => setSettings({ ...settings, wordWrap: value as 'on' | 'off' | 'wordWrapColumn' })}
+                                <label className={SETTINGS_LABEL}>{t('自动换行', 'Word Wrap')}</label>
+                                <Select value={settings.wordWrap} onChange={(value) => setSettings({ ...settings, wordWrap: value as 'on' | 'off' | 'wordWrapColumn' })}
                                     options={[{ value: 'on', label: 'On' }, { value: 'off', label: 'Off' }, { value: 'wordWrapColumn', label: 'Column' }]}
-                                    className={`w-full ${inputClass}`}
-                                />
+                                    className={`w-full ${SETTINGS_INPUT}`} />
                             </div>
                             <div>
-                                <label className={labelClass}>{language === 'zh' ? '行号' : 'Line Numbers'}</label>
-                                <Select
-                                    value={settings.lineNumbers}
-                                    onChange={(value) => setSettings({ ...settings, lineNumbers: value as 'on' | 'off' | 'relative' })}
+                                <label className={SETTINGS_LABEL}>{t('行号', 'Line Numbers')}</label>
+                                <Select value={settings.lineNumbers} onChange={(value) => setSettings({ ...settings, lineNumbers: value as 'on' | 'off' | 'relative' })}
                                     options={[{ value: 'on', label: 'On' }, { value: 'off', label: 'Off' }, { value: 'relative', label: 'Relative' }]}
-                                    className={`w-full ${inputClass}`}
-                                />
+                                    className={`w-full ${SETTINGS_INPUT}`} />
                             </div>
                         </div>
                     </section>
 
-                    <section className={sectionClass}>
+                    <section className={SETTINGS_SECTION}>
                         <div className="flex items-center gap-2 mb-1">
                             <Type className="w-4 h-4 text-accent" />
-                            <h5 className="text-sm font-bold text-text-primary">{language === 'zh' ? 'Agent 聊天区域' : 'Agent Chat Area'}</h5>
+                            <h5 className="text-sm font-bold text-text-primary">{t('Agent 聊天区域', 'Agent Chat Area')}</h5>
                         </div>
                         <div>
-                            <label className={labelClass}>{language === 'zh' ? '字体大小' : 'Font Size'}</label>
-                            <Input
-                                type="number"
-                                value={settings.chatFontSize}
-                                onChange={(e) => setSettings({ ...settings, chatFontSize: parseInt(e.target.value) || 14 })}
-                                min={10}
-                                max={32}
-                                className={inputClass}
-                            />
+                            <label className={SETTINGS_LABEL}>{t('字体大小', 'Font Size')}</label>
+                            <Input type="number" value={settings.chatFontSize} onChange={(e) => setSettings({ ...settings, chatFontSize: parseInt(e.target.value) || 14 })} min={10} max={32} className={SETTINGS_INPUT} />
                         </div>
                     </section>
+                </div>
+            </div>
 
-                    {/* Terminal Settings (Moved to Left) */}
-                    <section className={sectionClass}>
-                        <div className="flex items-center gap-2 mb-1">
-                            <Terminal className="w-4 h-4 text-accent" />
-                            <h5 className="text-sm font-bold text-text-primary">{language === 'zh' ? '终端配置' : 'Terminal'}</h5>
-                        </div>
-                        <div className="grid grid-cols-2 gap-5">
-                            <div>
-                                <label className={labelClass}>{language === 'zh' ? '字体大小' : 'Font Size'}</label>
-                                <Input type="number" value={advancedConfig.terminal.fontSize} onChange={(e) => setAdvancedConfig({ ...advancedConfig, terminal: { ...advancedConfig.terminal, fontSize: parseInt(e.target.value) || 13 } })} min={10} max={24} className={inputClass} />
-                            </div>
-                            <div>
-                                <label className={labelClass}>{language === 'zh' ? '行高' : 'Line Height'}</label>
-                                <Input type="number" value={advancedConfig.terminal.lineHeight} onChange={(e) => setAdvancedConfig({ ...advancedConfig, terminal: { ...advancedConfig.terminal, lineHeight: parseFloat(e.target.value) || 1.2 } })} min={1} max={2} step={0.1} className={inputClass} />
-                            </div>
-                            <div className="col-span-2">
-                                <label className={labelClass}>{language === 'zh' ? '滚动缓冲行数' : 'Scrollback Lines'}</label>
-                                <Input type="number" value={settings.terminalScrollback} onChange={(e) => setSettings({ ...settings, terminalScrollback: parseInt(e.target.value) || 1000 })} min={100} max={10000} step={100} className={inputClass} />
-                            </div>
-                        </div>
-                        <div className="pt-2">
-                            <Switch label={language === 'zh' ? '光标闪烁' : 'Cursor Blink'} checked={advancedConfig.terminal.cursorBlink} onChange={(e) => setAdvancedConfig({ ...advancedConfig, terminal: { ...advancedConfig.terminal, cursorBlink: e.target.checked } })} />
-                        </div>
-                    </section>
-
-                    {/* Features Switches */}
-                    <section className={sectionClass}>
+            {/* 功能特性 */}
+            <div className={activeSubTab === 'features' ? 'grid grid-cols-1 lg:grid-cols-2 gap-6' : 'hidden'}>
+                <div className="space-y-6">
+                    <section className={SETTINGS_SECTION}>
                         <div className="flex items-center gap-2 mb-1">
                             <Settings2 className="w-4 h-4 text-accent" />
-                            <h5 className="text-sm font-bold text-text-primary">{language === 'zh' ? '功能特性' : 'Features'}</h5>
+                            <h5 className="text-sm font-bold text-text-primary">{t('功能特性', 'Features')}</h5>
                         </div>
                         <div className="space-y-4 px-1">
-                            <Switch label={language === 'zh' ? '显示小地图' : 'Show Minimap'} checked={settings.minimap} onChange={(e) => setSettings({ ...settings, minimap: e.target.checked })} />
-                            <Switch label={language === 'zh' ? '括号配对着色' : 'Bracket Pair Colorization'} checked={settings.bracketPairColorization} onChange={(e) => setSettings({ ...settings, bracketPairColorization: e.target.checked })} />
-                            <Switch label={language === 'zh' ? '保存时格式化' : 'Format on Save'} checked={settings.formatOnSave} onChange={(e) => setSettings({ ...settings, formatOnSave: e.target.checked })} />
+                            <Switch label={t('显示小地图', 'Show Minimap')} checked={settings.minimap} onChange={(e) => setSettings({ ...settings, minimap: e.target.checked })} />
+                            <Switch label={t('括号配对着色', 'Bracket Pair Colorization')} checked={settings.bracketPairColorization} onChange={(e) => setSettings({ ...settings, bracketPairColorization: e.target.checked })} />
+                            <Switch label={t('保存时格式化', 'Format on Save')} checked={settings.formatOnSave} onChange={(e) => setSettings({ ...settings, formatOnSave: e.target.checked })} />
                         </div>
 
                         <div className="pt-4 border-t border-border/50">
                             <div className="flex items-center justify-between mb-4">
-                                <label className={labelClass.replace('mb-2', 'mb-0')}>{language === 'zh' ? '自动保存' : 'Auto Save'}</label>
-                                <Select
-                                    value={settings.autoSave}
-                                    onChange={(value) => setSettings({ ...settings, autoSave: value as 'off' | 'afterDelay' | 'onFocusChange' })}
-                                    options={[{ value: 'off', label: 'Off' }, { value: 'afterDelay', label: language === 'zh' ? '延迟后' : 'After Delay' }, { value: 'onFocusChange', label: language === 'zh' ? '失去焦点时' : 'On Focus Change' }]}
-                                    className={`w-40 ${inputClass}`}
-                                />
+                                <label className={SETTINGS_LABEL.replace('mb-2', 'mb-0')}>{t('自动保存', 'Auto Save')}</label>
+                                <Select value={settings.autoSave} onChange={(value) => setSettings({ ...settings, autoSave: value as 'off' | 'afterDelay' | 'onFocusChange' })}
+                                    options={[{ value: 'off', label: 'Off' }, { value: 'afterDelay', label: t('延迟后', 'After Delay') }, { value: 'onFocusChange', label: t('失去焦点时', 'On Focus Change') }]}
+                                    className={`w-40 ${SETTINGS_INPUT}`} />
                             </div>
                             {settings.autoSave === 'afterDelay' && (
                                 <div className="flex items-center justify-between animate-scale-in pl-1">
-                                    <label className="text-xs text-text-secondary">{language === 'zh' ? '延迟时间 (ms)' : 'Delay (ms)'}</label>
-                                    <Input
-                                        type="number"
-                                        value={settings.autoSaveDelay}
-                                        onChange={(e) => setSettings({ ...settings, autoSaveDelay: parseInt(e.target.value) || 1000 })}
-                                        min={500}
-                                        max={10000}
-                                        step={500}
-                                        className={`w-28 h-8 ${inputClass}`}
-                                    />
+                                    <label className="text-xs text-text-secondary">{t('延迟时间 (ms)', 'Delay (ms)')}</label>
+                                    <Input type="number" value={settings.autoSaveDelay} onChange={(e) => setSettings({ ...settings, autoSaveDelay: parseInt(e.target.value) || 1000 })}
+                                        min={500} max={10000} step={500} className={`w-28 h-8 ${SETTINGS_INPUT}`} />
                                 </div>
                             )}
                         </div>
                     </section>
                 </div>
+            </div>
 
-                {/* Right Column */}
+            {/* 终端 */}
+            <div className={activeSubTab === 'terminal' ? 'grid grid-cols-1 lg:grid-cols-2 gap-6' : 'hidden'}>
                 <div className="space-y-6">
-                    {/* AI Completion */}
-                    <section className="p-6 bg-gradient-to-br from-accent/5 to-transparent backdrop-blur-sm rounded-xl border border-accent/20 space-y-5 shadow-sm">
-                        <div className="flex items-center justify-between">
-                            <div className="flex items-center gap-2">
-                                <Sparkles className="w-4 h-4 text-accent" />
-                                <h5 className="text-sm font-bold text-text-primary">{language === 'zh' ? 'AI 代码补全' : 'AI Completion'}</h5>
-                            </div>
-                            <Switch checked={settings.completionEnabled} onChange={(e) => setSettings({ ...settings, completionEnabled: e.target.checked })} />
+                    <section className={SETTINGS_SECTION}>
+                        <div className="flex items-center gap-2 mb-1">
+                            <Terminal className="w-4 h-4 text-accent" />
+                            <h5 className="text-sm font-bold text-text-primary">{t('终端配置', 'Terminal')}</h5>
                         </div>
-
-                        {settings.completionEnabled && (
-                            <div className="space-y-5 pt-2 animate-scale-in">
-                                <div className="grid grid-cols-2 gap-5">
-                                    <div>
-                                        <label className={labelClass}>{language === 'zh' ? '触发延迟 (ms)' : 'Trigger Delay'}</label>
-                                        <Input
-                                            type="number"
-                                            value={settings.completionDebounceMs}
-                                            onChange={(e) => setSettings({ ...settings, completionDebounceMs: parseInt(e.target.value) || 150 })}
-                                            min={50}
-                                            max={1000}
-                                            step={50}
-                                            className={inputClass}
-                                        />
-                                    </div>
-                                    <div>
-                                        <label className={labelClass}>{language === 'zh' ? '最大 Token' : 'Max Tokens'}</label>
-                                        <Input
-                                            type="number"
-                                            value={settings.completionMaxTokens}
-                                            onChange={(e) => setSettings({ ...settings, completionMaxTokens: parseInt(e.target.value) || 256 })}
-                                            min={64}
-                                            max={1024}
-                                            step={64}
-                                            className={inputClass}
-                                        />
-                                    </div>
-                                </div>
-                                <div>
-                                    <label className={labelClass}>{language === 'zh' ? '触发字符' : 'Trigger Characters'}</label>
-                                    <div className="flex flex-wrap gap-2 p-3 bg-background/50 rounded-xl border border-border/50">
-                                        {TRIGGER_CHAR_OPTIONS.map(({ char, label }) => {
-                                            const isSelected = settings.completionTriggerChars.includes(char)
-                                            return (
-                                                <button
-                                                    key={char}
-                                                    type="button"
-                                                    onClick={() => toggleTriggerChar(char)}
-                                                    className={`w-8 h-8 rounded-lg text-sm font-mono flex items-center justify-center transition-all duration-200 ${isSelected
-                                                        ? 'bg-accent text-white shadow-md shadow-accent/20 scale-105'
-                                                        : 'bg-surface hover:bg-surface-hover text-text-secondary hover:text-text-primary border border-border/50'
-                                                        }`}
-                                                    title={char === ' ' ? 'Space' : char}
-                                                >
-                                                    {label}
-                                                </button>
-                                            )
-                                        })}
-                                    </div>
-                                    <p className="text-[10px] text-text-muted mt-2 ml-1">
-                                        {language === 'zh' ? '点击选择触发自动补全的特殊字符' : 'Select characters that trigger AI suggestions'}
-                                    </p>
-                                </div>
+                        <div className="grid grid-cols-2 gap-5">
+                            <div>
+                                <label className={SETTINGS_LABEL}>{t('字体大小', 'Font Size')}</label>
+                                <Input type="number" value={advancedConfig.terminal.fontSize} onChange={(e) => setAdvancedConfig({ ...advancedConfig, terminal: { ...advancedConfig.terminal, fontSize: parseInt(e.target.value) || 13 } })} min={10} max={24} className={SETTINGS_INPUT} />
                             </div>
-                        )}
+                            <div>
+                                <label className={SETTINGS_LABEL}>{t('行高', 'Line Height')}</label>
+                                <Input type="number" value={advancedConfig.terminal.lineHeight} onChange={(e) => setAdvancedConfig({ ...advancedConfig, terminal: { ...advancedConfig.terminal, lineHeight: parseFloat(e.target.value) || 1.2 } })} min={1} max={2} step={0.1} className={SETTINGS_INPUT} />
+                            </div>
+                            <div className="col-span-2">
+                                <label className={SETTINGS_LABEL}>{t('滚动缓冲行数', 'Scrollback Lines')}</label>
+                                <Input type="number" value={settings.terminalScrollback} onChange={(e) => setSettings({ ...settings, terminalScrollback: parseInt(e.target.value) || 1000 })} min={100} max={10000} step={100} className={SETTINGS_INPUT} />
+                            </div>
+                        </div>
+                        <div className="pt-2">
+                            <Switch label={t('光标闪烁', 'Cursor Blink')} checked={advancedConfig.terminal.cursorBlink} onChange={(e) => setAdvancedConfig({ ...advancedConfig, terminal: { ...advancedConfig.terminal, cursorBlink: e.target.checked } })} />
+                        </div>
                     </section>
 
-                    {/* Git Settings */}
-                    <section className={sectionClass}>
+                    <section className={SETTINGS_SECTION}>
                         <div className="flex items-center gap-2 mb-1">
                             <Settings2 className="w-4 h-4 text-accent" />
                             <h5 className="text-sm font-bold text-text-primary">Git</h5>
                         </div>
                         <div className="space-y-4 px-1">
                             <Switch
-                                label={language === 'zh' ? '自动刷新 Git 状态' : 'Auto Refresh Git Status'}
+                                label={t('自动刷新 Git 状态', 'Auto Refresh Git Status')}
                                 checked={advancedConfig.git?.autoRefresh ?? true}
                                 onChange={(e) => setAdvancedConfig({ ...advancedConfig, git: { ...advancedConfig.git, autoRefresh: e.target.checked } })}
                             />
                             <p className="text-[10px] text-text-muted opacity-80 leading-relaxed">
-                                {language === 'zh'
-                                    ? '检测到文件变化时自动更新侧边栏状态。'
-                                    : 'Automatically refresh git indicators when file changes are detected.'}
+                                {t('检测到文件变化时自动更新侧边栏状态。', 'Automatically refresh git indicators when file changes are detected.')}
                             </p>
                         </div>
                     </section>
-
-                    {/* Performance */}
-                    <section className={sectionClass}>
-                        <div className="flex items-center gap-2 mb-1">
-                            <Zap className="w-4 h-4 text-accent" />
-                            <h5 className="text-sm font-bold text-text-primary">{language === 'zh' ? '性能与限制' : 'Performance'}</h5>
-                        </div>
-                        <div className="grid grid-cols-2 gap-4">
-                            <div className="space-y-1">
-                                <label className="text-xs font-medium text-text-secondary">{language === 'zh' ? '大文件警告 (MB)' : 'Large File Warning (MB)'}</label>
-                                <Input type="number" value={settings.largeFileWarningThresholdMB} onChange={(e) => setSettings({ ...settings, largeFileWarningThresholdMB: parseFloat(e.target.value) || 5 })} min={1} max={50} step={1} className={inputClass} />
-                            </div>
-                            <div className="space-y-1">
-                                <label className="text-xs font-medium text-text-secondary">{language === 'zh' ? '大文件行数阈值' : 'Large File Line Count'}</label>
-                                <Input type="number" value={settings.largeFileLineCount} onChange={(e) => setSettings({ ...settings, largeFileLineCount: parseInt(e.target.value) || 10000 })} min={1000} max={100000} step={1000} className={inputClass} />
-                            </div>
-                            <div className="space-y-1">
-                                <label className="text-xs font-medium text-text-secondary">{language === 'zh' ? '命令超时 (秒)' : 'Command Timeout (s)'}</label>
-                                <Input type="number" value={settings.commandTimeoutMs / 1000} onChange={(e) => setSettings({ ...settings, commandTimeoutMs: (parseInt(e.target.value) || 30) * 1000 })} min={10} max={300} step={10} className={inputClass} />
-                            </div>
-                            <div className="space-y-1">
-                                <label className="text-xs font-medium text-text-secondary">{language === 'zh' ? '最大扫描文件数' : 'Max Project Files'}</label>
-                                <Input type="number" value={settings.maxProjectFiles} onChange={(e) => setSettings({ ...settings, maxProjectFiles: parseInt(e.target.value) || 500 })} min={100} max={2000} step={100} className={inputClass} />
-                            </div>
-                            <div className="space-y-1">
-                                <label className="text-xs font-medium text-text-secondary">{language === 'zh' ? '文件树最大深度' : 'File Tree Max Depth'}</label>
-                                <Input type="number" value={settings.maxFileTreeDepth} onChange={(e) => setSettings({ ...settings, maxFileTreeDepth: parseInt(e.target.value) || 5 })} min={2} max={15} step={1} className={inputClass} />
-                            </div>
-                            <div className="space-y-1">
-                                <label className="text-xs font-medium text-text-secondary">{language === 'zh' ? '最大搜索结果数' : 'Max Search Results'}</label>
-                                <Input type="number" value={settings.maxSearchResults} onChange={(e) => setSettings({ ...settings, maxSearchResults: parseInt(e.target.value) || 1000 })} min={100} max={5000} step={100} className={inputClass} />
-                            </div>
-                        </div>
-                    </section>
                 </div>
+            </div>
+
+            {/* AI 补全 */}
+            <div className={activeSubTab === 'ai-completion' ? '' : 'hidden'}>
+                <section className="p-6 bg-gradient-to-br from-accent/5 to-transparent backdrop-blur-sm rounded-xl border border-accent/20 space-y-5 shadow-sm">
+                    <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                            <Sparkles className="w-4 h-4 text-accent" />
+                            <h5 className="text-sm font-bold text-text-primary">{t('AI 代码补全', 'AI Completion')}</h5>
+                        </div>
+                        <Switch checked={settings.completionEnabled} onChange={(e) => setSettings({ ...settings, completionEnabled: e.target.checked })} />
+                    </div>
+
+                    {settings.completionEnabled && (
+                        <div className="space-y-5 pt-2 animate-scale-in">
+                            <div className="grid grid-cols-2 gap-5">
+                                <div>
+                                    <label className={SETTINGS_LABEL}>{t('触发延迟 (ms)', 'Trigger Delay')}</label>
+                                    <Input type="number" value={settings.completionDebounceMs} onChange={(e) => setSettings({ ...settings, completionDebounceMs: parseInt(e.target.value) || 150 })} min={50} max={1000} step={50} className={SETTINGS_INPUT} />
+                                </div>
+                                <div>
+                                    <label className={SETTINGS_LABEL}>{t('最大 Token', 'Max Tokens')}</label>
+                                    <Input type="number" value={settings.completionMaxTokens} onChange={(e) => setSettings({ ...settings, completionMaxTokens: parseInt(e.target.value) || 256 })} min={64} max={1024} step={64} className={SETTINGS_INPUT} />
+                                </div>
+                            </div>
+                            <div>
+                                <label className={SETTINGS_LABEL}>{t('触发字符', 'Trigger Characters')}</label>
+                                <div className="flex flex-wrap gap-2 p-3 bg-background/50 rounded-xl border border-border/50">
+                                    {TRIGGER_CHAR_OPTIONS.map(({ char, label }) => {
+                                        const isSelected = settings.completionTriggerChars.includes(char)
+                                        return (
+                                            <button key={char} type="button" onClick={() => toggleTriggerChar(char)}
+                                                className={`w-8 h-8 rounded-lg text-sm font-mono flex items-center justify-center transition-all duration-200 ${
+                                                    isSelected ? 'bg-accent text-white shadow-md shadow-accent/20 scale-105' : 'bg-surface hover:bg-surface-hover text-text-secondary hover:text-text-primary border border-border/50'
+                                                }`}
+                                                title={char === ' ' ? 'Space' : char}>
+                                                {label}
+                                            </button>
+                                        )
+                                    })}
+                                </div>
+                                <p className="text-[10px] text-text-muted mt-2 ml-1">{t('点击选择触发自动补全的特殊字符', 'Select characters that trigger AI suggestions')}</p>
+                            </div>
+                        </div>
+                    )}
+                </section>
+            </div>
+
+            {/* 性能 */}
+            <div className={activeSubTab === 'performance' ? '' : 'hidden'}>
+                <section className={SETTINGS_SECTION}>
+                    <div className="flex items-center gap-2 mb-1">
+                        <Zap className="w-4 h-4 text-accent" />
+                        <h5 className="text-sm font-bold text-text-primary">{t('性能与限制', 'Performance')}</h5>
+                    </div>
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-1">
+                            <label className="text-xs font-medium text-text-secondary">{t('大文件警告 (MB)', 'Large File Warning (MB)')}</label>
+                            <Input type="number" value={settings.largeFileWarningThresholdMB} onChange={(e) => setSettings({ ...settings, largeFileWarningThresholdMB: parseFloat(e.target.value) || 5 })} min={1} max={50} step={1} className={SETTINGS_INPUT} />
+                        </div>
+                        <div className="space-y-1">
+                            <label className="text-xs font-medium text-text-secondary">{t('大文件行数阈值', 'Large File Line Count')}</label>
+                            <Input type="number" value={settings.largeFileLineCount} onChange={(e) => setSettings({ ...settings, largeFileLineCount: parseInt(e.target.value) || 10000 })} min={1000} max={100000} step={1000} className={SETTINGS_INPUT} />
+                        </div>
+                        <div className="space-y-1">
+                            <label className="text-xs font-medium text-text-secondary">{t('命令超时 (秒)', 'Command Timeout (s)')}</label>
+                            <Input type="number" value={settings.commandTimeoutMs / 1000} onChange={(e) => setSettings({ ...settings, commandTimeoutMs: (parseInt(e.target.value) || 30) * 1000 })} min={10} max={300} step={10} className={SETTINGS_INPUT} />
+                        </div>
+                        <div className="space-y-1">
+                            <label className="text-xs font-medium text-text-secondary">{t('最大扫描文件数', 'Max Project Files')}</label>
+                            <Input type="number" value={settings.maxProjectFiles} onChange={(e) => setSettings({ ...settings, maxProjectFiles: parseInt(e.target.value) || 500 })} min={100} max={2000} step={100} className={SETTINGS_INPUT} />
+                        </div>
+                        <div className="space-y-1">
+                            <label className="text-xs font-medium text-text-secondary">{t('文件树最大深度', 'File Tree Max Depth')}</label>
+                            <Input type="number" value={settings.maxFileTreeDepth} onChange={(e) => setSettings({ ...settings, maxFileTreeDepth: parseInt(e.target.value) || 5 })} min={2} max={15} step={1} className={SETTINGS_INPUT} />
+                        </div>
+                        <div className="space-y-1">
+                            <label className="text-xs font-medium text-text-secondary">{t('最大搜索结果数', 'Max Search Results')}</label>
+                            <Input type="number" value={settings.maxSearchResults} onChange={(e) => setSettings({ ...settings, maxSearchResults: parseInt(e.target.value) || 1000 })} min={100} max={5000} step={100} className={SETTINGS_INPUT} />
+                        </div>
+                    </div>
+                </section>
             </div>
         </div>
     )

--- a/src/renderer/components/settings/tabs/IndexSettings.tsx
+++ b/src/renderer/components/settings/tabs/IndexSettings.tsx
@@ -9,6 +9,7 @@ import { Eye, EyeOff, AlertTriangle, Database, Settings2, Zap, Brain } from 'luc
 import { useStore } from '@store'
 import { toast } from '@components/common/ToastProvider'
 import { Button, Input, Select } from '@components/ui'
+import { SETTINGS_PAGE, SETTINGS_SECTION, SETTINGS_LABEL, SETTINGS_INPUT } from '../types'
 import { Language } from '@renderer/i18n'
 import type { EmbeddingConfigInput, IndexStatus } from '@renderer/types/electron'
 
@@ -171,7 +172,7 @@ export function IndexSettings({ language }: IndexSettingsProps) {
   }
 
   return (
-    <div className="space-y-6 animate-fade-in">
+    <div className={SETTINGS_PAGE}>
       {/* 索引模式选择 */}
       <section>
         <h4 className="text-xs font-medium text-text-secondary uppercase tracking-wider mb-3">

--- a/src/renderer/components/settings/tabs/LspSettings.tsx
+++ b/src/renderer/components/settings/tabs/LspSettings.tsx
@@ -20,6 +20,7 @@ import {
 import { Language } from '@renderer/i18n'
 import { api } from '@/renderer/services/electronAPI'
 import { Button, Input } from '@components/ui'
+import { SETTINGS_PAGE } from '../types'
 import { LSP_SERVER_DEFINITIONS } from '@shared/languages'
 
 interface LspSettingsProps {
@@ -178,7 +179,7 @@ export function LspSettings({ language }: LspSettingsProps) {
   }
 
   return (
-    <div className="space-y-8">
+    <div className={SETTINGS_PAGE}>
       {/* 错误提示 */}
       {error && (
         <div className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm">

--- a/src/renderer/components/settings/tabs/McpSettings.tsx
+++ b/src/renderer/components/settings/tabs/McpSettings.tsx
@@ -34,6 +34,7 @@ import { isRemoteConfig, isLocalConfig } from '@shared/types/mcp'
 import { MCP_PRESETS } from '@shared/config/mcpPresets'
 import McpAddServerModal, { type McpServerFormData } from './McpAddServerModal'
 import { OtterAsset } from '@/renderer/components/brand/OtterAsset'
+import { SETTINGS_PAGE } from '../types'
 
 interface McpSettingsProps {
   language: 'en' | 'zh'
@@ -625,7 +626,7 @@ export default function McpSettings({ language, mcpConfig, setMcpConfig }: McpSe
   const existingServerIds = mcpServers.map(s => s.id)
 
   return (
-    <div className="space-y-6">
+    <div className={SETTINGS_PAGE}>
       {/* Auto Connect Setting */}
       <div className="p-4 bg-surface/20 rounded-xl border border-border">
         <div className="flex items-center justify-between">

--- a/src/renderer/components/settings/tabs/ProviderSettings.tsx
+++ b/src/renderer/components/settings/tabs/ProviderSettings.tsx
@@ -21,7 +21,7 @@ import { LLM_DEFAULTS } from '@/shared/config/defaults'
 import { globalConfirm } from '@components/common/ConfirmDialog'
 import { toast } from '@components/common/ToastProvider'
 import { Button, Input, Select, Switch } from '@components/ui'
-import { ProviderSettingsProps } from '../types'
+import { ProviderSettingsProps, SETTINGS_PAGE } from '../types'
 import { isCustomProvider } from '@renderer/types/provider'
 
 // 内置厂商 ID
@@ -1222,7 +1222,7 @@ export function ProviderSettings({
   }, [collectProviderModels, selectedMultimodalProviderId])
 
   return (
-    <div className="space-y-6 animate-fade-in pb-10">
+    <div className={SETTINGS_PAGE}>
       {/* Provider 选择器 */}
       <section className="space-y-4">
         <div className="mb-4">

--- a/src/renderer/components/settings/tabs/RulesMemorySettings.tsx
+++ b/src/renderer/components/settings/tabs/RulesMemorySettings.tsx
@@ -14,6 +14,7 @@ import {
   RefreshCw, AlertCircle, ToggleLeft, ToggleRight
 } from 'lucide-react'
 import { OtterAsset } from '@/renderer/components/brand/OtterAsset'
+import { SETTINGS_PAGE } from '../types'
 
 interface RulesMemorySettingsProps {
   language: string
@@ -117,7 +118,7 @@ export function RulesMemorySettings({ language }: RulesMemorySettingsProps) {
   }
 
   return (
-    <div className="space-y-8 animate-fade-in pb-10">
+    <div className={SETTINGS_PAGE}>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Left: Project Rules */}
         <section className="p-5 bg-surface/30 rounded-xl border border-border space-y-4">

--- a/src/renderer/components/settings/tabs/SecuritySettings.tsx
+++ b/src/renderer/components/settings/tabs/SecuritySettings.tsx
@@ -1,6 +1,7 @@
 import { useState, type Dispatch, type SetStateAction } from 'react'
 import { AlertTriangle, Plus, X, RotateCcw } from 'lucide-react'
 import { Switch } from '@components/ui'
+import { SETTINGS_PAGE, SETTINGS_SECTION } from '../types'
 import { toast } from '@components/common/ToastProvider'
 import { type Language } from '@renderer/i18n'
 import { api } from '@renderer/services/electronAPI'
@@ -65,7 +66,7 @@ export function SecuritySettings({ language, securitySettings, setSecuritySettin
     }
 
     return (
-        <div className="space-y-8 animate-fade-in pb-10">
+        <div className={SETTINGS_PAGE}>
             <div className="p-5 bg-yellow-500/10 border border-yellow-500/20 rounded-2xl flex items-start gap-4 shadow-sm">
                 <div className="p-2 bg-yellow-500/10 rounded-lg shrink-0">
                     <AlertTriangle className="w-5 h-5 text-yellow-500" />
@@ -82,7 +83,7 @@ export function SecuritySettings({ language, securitySettings, setSecuritySettin
                 </div>
             </div>
 
-            <section className="space-y-5 p-6 bg-surface/20 backdrop-blur-md rounded-2xl border border-border shadow-sm">
+            <section className={SETTINGS_SECTION}>
                 <h4 className="text-[11px] font-bold text-text-muted uppercase tracking-widest opacity-60 ml-1">
                     {language === 'zh' ? '安全选项' : 'Security Options'}
                 </h4>
@@ -108,7 +109,7 @@ export function SecuritySettings({ language, securitySettings, setSecuritySettin
                 </div>
             </section>
 
-            <section className="space-y-4 p-6 bg-surface/20 backdrop-blur-md rounded-2xl border border-border shadow-sm">
+            <section className={SETTINGS_SECTION}>
                 <div className="flex items-center justify-between">
                     <h4 className="text-[11px] font-bold text-text-muted uppercase tracking-widest opacity-60">
                         {language === 'zh' ? 'Shell 命令白名单' : 'Shell Command Whitelist'}
@@ -154,7 +155,7 @@ export function SecuritySettings({ language, securitySettings, setSecuritySettin
                 </div>
             </section>
 
-            <section className="space-y-4 p-6 bg-surface/20 backdrop-blur-md rounded-2xl border border-border shadow-sm">
+            <section className={SETTINGS_SECTION}>
                 <h4 className="text-[11px] font-bold text-text-muted uppercase tracking-widest opacity-60">
                     {language === 'zh' ? 'Git 子命令白名单' : 'Git Subcommand Whitelist'}
                 </h4>

--- a/src/renderer/components/settings/tabs/SkillSettings.tsx
+++ b/src/renderer/components/settings/tabs/SkillSettings.tsx
@@ -16,6 +16,7 @@ import {
     ToggleLeft, ToggleRight, ExternalLink, Github, FolderOpen
 } from 'lucide-react'
 import { OtterAsset } from '@/renderer/components/brand/OtterAsset'
+import { SETTINGS_PAGE } from '../types'
 
 interface SkillSettingsProps {
     language: string
@@ -199,7 +200,7 @@ export function SkillSettings({ language }: SkillSettingsProps) {
         )
 
     return (
-        <div className="space-y-6 animate-fade-in pb-10">
+        <div className={SETTINGS_PAGE}>
             {/* Header */}
             <section className="p-5 bg-surface/30 rounded-xl border border-border space-y-4">
                 <div className="flex items-center justify-between">

--- a/src/renderer/components/settings/tabs/SnippetSettings.tsx
+++ b/src/renderer/components/settings/tabs/SnippetSettings.tsx
@@ -10,6 +10,7 @@ import { globalConfirm } from '@components/common/ConfirmDialog'
 import { toast } from '@components/common/ToastProvider'
 import { snippetService, type CodeSnippet } from '@services/snippetService'
 import { Language } from '@renderer/i18n'
+import { SETTINGS_PAGE } from '../types'
 import { OtterAsset } from '@/renderer/components/brand/OtterAsset'
 
 interface SnippetSettingsProps {
@@ -192,7 +193,7 @@ export function SnippetSettings({ language }: SnippetSettingsProps) {
   }
 
   return (
-    <div className="space-y-6 animate-fade-in pb-10">
+    <div className={SETTINGS_PAGE}>
       {/* Header Actions */}
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-2 flex-1">

--- a/src/renderer/components/settings/tabs/SystemSettings.tsx
+++ b/src/renderer/components/settings/tabs/SystemSettings.tsx
@@ -10,6 +10,7 @@ import { toast } from '@components/common/ToastProvider'
 import { globalConfirm } from '@components/common/ConfirmDialog'
 import { Button, Switch } from '@components/ui'
 import { Language } from '@renderer/i18n'
+import { SETTINGS_PAGE, SETTINGS_DESC } from '../types'
 import { useStore } from '@store'
 import { downloadSettings, importSettings, settingsService } from '@renderer/settings'
 import { Agent } from '@/renderer/agent/core'
@@ -247,7 +248,7 @@ export function SystemSettings({ language, enableFileLogging, setEnableFileLoggi
     }
 
     return (
-        <div className="space-y-8 animate-fade-in pb-10">
+        <div className={SETTINGS_PAGE}>
             <section>
                 <div className="flex items-center gap-2 mb-5 ml-1">
                     <ExternalLink className="w-4 h-4 text-accent" />
@@ -261,7 +262,7 @@ export function SystemSettings({ language, enableFileLogging, setEnableFileLoggi
                             <div className="text-sm font-bold text-text-primary">
                                 {language === 'zh' ? 'GitHub Token' : 'GitHub Token'}
                             </div>
-                            <div className="text-xs text-text-muted mt-1 opacity-70">
+                            <div className={SETTINGS_DESC}>
                                 {language === 'zh'
                                     ? '用于 GitHub Releases 请求，减少速率限制，供 LSP 安装和更新检查复用'
                                     : 'Used for GitHub Releases requests to reduce rate limiting across LSP installs and update checks'}
@@ -302,7 +303,7 @@ export function SystemSettings({ language, enableFileLogging, setEnableFileLoggi
                         <div className="flex items-center justify-between">
                             <div>
                                 <div className="text-sm font-bold text-text-primary">{language === 'zh' ? '配置存储路径' : 'Config Storage Path'}</div>
-                                <div className="text-xs text-text-muted mt-1 opacity-70">
+                                <div className={SETTINGS_DESC}>
                                     {language === 'zh'
                                         ? '所有配置文件（config.json、mcp.json 等）的存储位置'
                                         : 'Storage location for all config files (config.json, mcp.json, etc.)'}
@@ -342,7 +343,7 @@ export function SystemSettings({ language, enableFileLogging, setEnableFileLoggi
                     <div className="flex items-center justify-between p-6 bg-surface/20 backdrop-blur-md rounded-2xl border border-border shadow-sm">
                         <div>
                             <div className="text-sm font-bold text-text-primary">{language === 'zh' ? '清除缓存' : 'Clear Cache'}</div>
-                            <div className="text-xs text-text-muted mt-1 opacity-70">{language === 'zh' ? '清除业务缓存、索引数据和临时文件' : 'Clear app caches, index data, and temporary files'}</div>
+                            <div className={SETTINGS_DESC}>{language === 'zh' ? '清除业务缓存、索引数据和临时文件' : 'Clear app caches, index data, and temporary files'}</div>
                         </div>
                         <div className="flex gap-2">
                             <Button variant="secondary" size="sm" onClick={handleClearCache} disabled={isClearing} className="rounded-xl px-6">
@@ -381,7 +382,7 @@ export function SystemSettings({ language, enableFileLogging, setEnableFileLoggi
                                 <div className="text-sm font-bold text-text-primary">
                                     {language === 'zh' ? '启用文件日志' : 'Enable File Logging'}
                                 </div>
-                                <div className="text-xs text-text-muted mt-1 opacity-70">
+                                <div className={SETTINGS_DESC}>
                                     {language === 'zh'
                                         ? '将应用日志保存到文件，用于调试和问题排查'
                                         : 'Save application logs to file for debugging and troubleshooting'}
@@ -470,7 +471,7 @@ export function SystemSettings({ language, enableFileLogging, setEnableFileLoggi
                         <div className="flex items-center justify-between">
                             <div>
                                 <div className="text-sm font-bold text-text-primary">{language === 'zh' ? '导出配置' : 'Export Settings'}</div>
-                                <div className="text-xs text-text-muted mt-1 opacity-70">
+                                <div className={SETTINGS_DESC}>
                                     {language === 'zh'
                                         ? '将当前配置导出为 JSON 文件，方便备份或迁移'
                                         : 'Export current settings to JSON file for backup or migration'}
@@ -503,7 +504,7 @@ export function SystemSettings({ language, enableFileLogging, setEnableFileLoggi
                     <div className="flex items-center justify-between p-6 bg-surface/20 backdrop-blur-md rounded-2xl border border-border shadow-sm">
                         <div>
                             <div className="text-sm font-bold text-text-primary">{language === 'zh' ? '导入配置' : 'Import Settings'}</div>
-                            <div className="text-xs text-text-muted mt-1 opacity-70">
+                            <div className={SETTINGS_DESC}>
                                 {language === 'zh' ? '从 JSON 文件导入配置' : 'Import settings from JSON file'}
                             </div>
                         </div>

--- a/src/renderer/components/settings/types.ts
+++ b/src/renderer/components/settings/types.ts
@@ -92,6 +92,33 @@ export interface PromptPreviewModalProps {
     onClose: () => void
 }
 
+// ========== 共享样式常量 ==========
+// 所有设置 Tab 统一使用这些常量，确保排版一致性
+
+/** 页面外层容器 */
+export const SETTINGS_PAGE = "space-y-8 animate-fade-in pb-10"
+
+/** Section 卡片容器 */
+export const SETTINGS_SECTION = "p-6 bg-surface/30 backdrop-blur-sm rounded-xl border border-border/50 space-y-5 shadow-sm hover:border-border transition-colors duration-300"
+
+/** Section 标签文字 */
+export const SETTINGS_LABEL = "text-xs font-semibold text-text-secondary uppercase tracking-wider ml-1 mb-2 block"
+
+/** 输入框/下拉框统一样式 */
+export const SETTINGS_INPUT = "bg-background/50 border-border/50 text-xs rounded-lg focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all"
+
+/** Section 标题行（带图标） */
+export const SETTINGS_SECTION_HEADER = "flex items-center gap-2 mb-1"
+
+/** Section 标题文字 */
+export const SETTINGS_SECTION_TITLE = "text-sm font-bold text-text-primary"
+
+/** 外层 Group 标题 */
+export const SETTINGS_GROUP_TITLE = "text-[11px] font-bold text-text-muted uppercase tracking-[0.2em]"
+
+/** 次级描述文字 */
+export const SETTINGS_DESC = "text-xs text-text-muted mt-1 opacity-70"
+
 export const LANGUAGES: { id: Language; name: string }[] = [
     { id: 'en', name: 'English' },
     { id: 'zh', name: '中文' },

--- a/src/renderer/components/sidebar/Sidebar.tsx
+++ b/src/renderer/components/sidebar/Sidebar.tsx
@@ -9,7 +9,6 @@ import { SearchView } from './panels/SearchView'
 import { GitView } from './panels/GitView'
 import { ProblemsView } from './panels/ProblemsView'
 import { OutlineView } from './panels/OutlineView'
-import { HistoryView } from './panels/HistoryView'
 import { ShellView } from './panels/ShellView'
 import { EmotionAwarenessPanel } from '../agent/EmotionAwarenessPanel'
 
@@ -26,7 +25,6 @@ export default function Sidebar() {
             {activeSidePanel === 'emotion' && <EmotionAwarenessPanel />}
             {activeSidePanel === 'problems' && <ProblemsView />}
             {activeSidePanel === 'outline' && <OutlineView />}
-            {activeSidePanel === 'history' && <HistoryView />}
             {activeSidePanel === 'shell' && <ShellView />}
         </div>
     )

--- a/src/renderer/store/slices/layoutSlice.ts
+++ b/src/renderer/store/slices/layoutSlice.ts
@@ -4,7 +4,7 @@
  */
 import { StateCreator } from 'zustand'
 
-export type SidePanel = 'explorer' | 'search' | 'git' | 'problems' | 'outline' | 'history' | 'extensions' | 'emotion' | 'shell' | null
+export type SidePanel = 'explorer' | 'search' | 'git' | 'problems' | 'outline' | 'extensions' | 'emotion' | 'shell' | null
 
 export interface LayoutSlice {
   activeSidePanel: SidePanel


### PR DESCRIPTION
## Summary

Two-part refactoring of the settings panel:

### Part 1: Settings Sidebar Grouped Navigation
- Replaced flat 12-tab sidebar with hierarchical sidebar groups: AI (Providers, Agent, MCP, Skills), Editor (Editor, Snippets, LSP, Keybindings), Project (Rules & Memory, Indexing), System (Security, System)
- Each group displays a section label for visual hierarchy

### Part 2: Editor Sub-navigation & Style Unification
- Added secondary Pill navigation inside the Editor tab: Theme, Typography, Features, Terminal, AI Completion, Performance
- Extracted shared style constants (SETTINGS_PAGE, SETTINGS_SECTION, SETTINGS_LABEL, SETTINGS_INPUT, SETTINGS_DESC) into types.ts
- Unified all 11 tab files to use shared constants, eliminating inconsistent spacing, missing animations, and hardcoded style strings

## Test Plan

- [ ] Verify settings modal opens and sidebar shows grouped sections with labels
- [ ] Verify clicking each sidebar group tab navigates correctly
- [ ] Verify Editor tab shows secondary sub-nav pill bar
- [ ] Verify switching between sub-tabs shows/hides correct sections, preserving input state
- [ ] Verify all settings tabs render without visual regressions
- [ ] Verify no TypeScript/linter errors in touched files