### PR TITLE
Potential fix for code scanning alert no. 20: Incomplete string escaping or encoding

### DIFF
--- a/src/main/indexing/vectorStore.ts
+++ b/src/main/indexing/vectorStore.ts
@@ -462,6 +462,7 @@ export class VectorStoreService {
    */
   private sanitizeKeyword(keyword: string): string {
     return keyword
+      .replace(/\\/g, '\\\\')
       .replace(/'/g, "''")
       .replace(/%/g, '\\%')
       .replace(/_/g, '\\_')


### PR DESCRIPTION
Potential fix for [https://github.com/ad-naan/Adnify/security/code-scanning/20](https://github.com/ad-naan/Adnify/security/code-scanning/20)

To fix this without changing intended functionality, update `sanitizeKeyword` so it escapes backslashes **before** escaping other wildcard/meta characters. Ordering matters: if `%` and `_` are escaped first, a later backslash-escape step could alter those newly inserted backslashes. The best fix is to add `.replace(/\\/g, '\\\\')` at the start of the replace chain in `sanitizeKeyword`.

Edit only `src/main/indexing/vectorStore.ts`, within `sanitizeKeyword` (around lines 463–470). No new imports, helpers, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
