### PR TITLE
Potential fix for code scanning alert no. 23: Bad HTML filtering regexp

### DIFF
--- a/src/renderer/components/common/SafeHTML.tsx
+++ b/src/renderer/components/common/SafeHTML.tsx
@@ -97,7 +97,7 @@ function escapeHtml(unsafe: string): string {
  */
 function containsDangerousContent(html: string): boolean {
   const dangerousPatterns = [
-    /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+    /<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi,
     /javascript:/gi,
     /on\w+\s*=/gi, // onclick, onerror 等事件处理器
     /<iframe\b/gi,


### PR DESCRIPTION
Potential fix for [https://github.com/ad-naan/Adnify/security/code-scanning/23](https://github.com/ad-naan/Adnify/security/code-scanning/23)

通用修复思路：不要用脆弱正则去精确匹配完整 `<script>...</script>` 结构；如果只是“是否包含危险内容”的启发式检查，应改为更稳健、容错的模式，至少覆盖浏览器可接受的结束标签写法。

本文件里最佳单点修复：将第 100 行脚本检测正则替换为更宽松且容错的版本，允许 `</script` 后跟空白或其他属性直到 `>`。  
具体改动位于 `src/renderer/components/common/SafeHTML.tsx` 的 `containsDangerousContent` 函数中 `dangerousPatterns` 数组：

- 把  
  `/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi`  
  改为  
  `/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi`

这样可匹配 `</script >`、`</script foo="bar">` 等容错结束标签形式，避免 CodeQL 指出的漏检。


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
